### PR TITLE
Fork Presto ES connector for continued ES 6 support

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,30 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with: 
+        show-progress: false
+        # needed for the git-commit-id-plugin to work
+        fetch-depth: 0
+    - name: Set up JDK 8
+      uses: actions/setup-java@v3
+      with:
+        java-version: '8'
+        distribution: 'temurin'
+        cache: maven
+    - name: Maven verify
+      run: mvn verify

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,500 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.facebook.presto</groupId>
+        <artifactId>presto-root</artifactId>
+        <version>0.289-SNAPSHOT</version>
+    </parent>
+    <artifactId>presto-elasticsearch-6</artifactId>
+    <description>Presto - Elasticsearch v6 Connector</description>
+    <packaging>presto-plugin</packaging>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <properties>
+        <dep.log4j.version>2.17.1</dep.log4j.version>
+        <dep.elasticsearch.version>6.0.0</dep.elasticsearch.version>
+        <dep.snakeyaml.version>2.0</dep.snakeyaml.version>
+        <dep.presto.parent.version>0.289-SNAPSHOT</dep.presto.parent.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>${dep.snakeyaml.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-record-decoder</artifactId>
+            <version>${dep.presto.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>concurrent</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <!-- org.elasticsearch:elasticsearch brings in version 2.8.6 (vs 2.6.7) -->
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-cbor</artifactId>
+                </exclusion>
+
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>elasticsearch-rest-high-level-client</artifactId>
+            <version>${dep.elasticsearch.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>elasticsearch-rest-client</artifactId>
+            <version>${dep.elasticsearch.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore-nio</artifactId>
+            <version>4.4.5</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.2</version>
+
+            <exclusions>
+                <!-- elasticsearch-rest-high-level-client 6.0.0 brings in httpcore 4.4.5 vs (4.4.4) -->
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpcore</artifactId>
+                </exclusion>
+
+                    <!-- elasticsearch-rest-high-level-client 6.0.0 brings in commons-codec 1.10 vs (1.9) -->
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>4.4.5</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpasyncclient</artifactId>
+            <version>4.1.2</version>
+
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>security</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${dep.log4j.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${dep.log4j.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>log-manager</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-geospatial-toolkit</artifactId>
+            <version>${dep.presto.parent.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-analyzer</artifactId>
+            <version>${dep.presto.parent.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-bytecode</artifactId>
+            <version>${dep.presto.parent.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-parser</artifactId>
+            <version>${dep.presto.parent.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-matching</artifactId>
+            <version>${dep.presto.parent.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-memory-context</artifactId>
+            <version>${dep.presto.parent.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-expressions</artifactId>
+            <version>${dep.presto.parent.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-plugin-toolkit</artifactId>
+            <version>${dep.presto.parent.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-ui</artifactId>
+            <version>${dep.presto.parent.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-blackhole</artifactId>
+            <version>${dep.presto.parent.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-function-namespace-managers</artifactId>
+            <version>${dep.presto.parent.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-thrift-api</artifactId>
+            <version>${dep.presto.parent.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- provided -->
+        <dependency>
+            <groupId>org.openjdk.jol</groupId>
+            <artifactId>jol-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+            <scope>provided</scope>
+            <version>${dep.presto.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-common</artifactId>
+            <scope>provided</scope>
+            <version>${dep.presto.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <!-- for testing -->
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>19.0.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>elasticsearch</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-compress</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <version>${dep.presto.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-client</artifactId>
+            <scope>test</scope>
+            <version>${dep.presto.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+            <scope>test</scope>
+            <version>${dep.presto.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-tests</artifactId>
+            <scope>test</scope>
+            <version>${dep.presto.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-tpch</artifactId>
+            <scope>test</scope>
+            <version>${dep.presto.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>http-server</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>node</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift.tpch</groupId>
+            <artifactId>tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.elasticsearch.plugin</groupId>
+            <artifactId>transport-netty4-client</artifactId>
+            <version>${dep.elasticsearch.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                 <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                 </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch</artifactId>
+            <version>${dep.elasticsearch.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.elasticsearch</groupId>
+                    <artifactId>jna</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <ignoredDependencies>
+                        <ignoredDependency>org.yaml:snakeyaml:jar</ignoredDependency>
+                    </ignoredDependencies>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>duplicate-finder-maven-plugin</artifactId>
+                <configuration>
+                    <ignoredClassPatterns>
+                        <ignoredClassPattern>META-INF.versions.9.module-info</ignoredClassPattern>
+                        <ignoredClassPattern>module-info</ignoredClassPattern>
+                    </ignoredClassPatterns>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/checkstyle/presto-checks.xml
+++ b/src/checkstyle/presto-checks.xml
@@ -1,0 +1,222 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="FileTabCharacter" />
+    <module name="NewlineAtEndOfFile">
+        <property name="lineSeparator" value="lf" />
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="\r" />
+        <property name="message" value="Line contains carriage return" />
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value=" \n" />
+        <property name="message" value="Line has trailing whitespace" />
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="\n\n\n" />
+        <property name="message" value="Multiple consecutive blank lines" />
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="\n\n\Z" />
+        <property name="message" value="Blank line before end of file" />
+    </module>
+
+    <module name="RegexpMultiline">
+        <property name="format" value="\{\n\n" />
+        <property name="message" value="Blank line after opening brace" />
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="\n\n\s*\}" />
+        <property name="message" value="Blank line before closing brace" />
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="[^;]\s\)+\s*[\{;,]?\s*\n" />
+        <property name="message" value="Whitespace character before closing parenthesis" />
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="->\s*\{\s+\}" />
+        <property name="message" value="Whitespace inside empty lambda body" />
+    </module>
+    <module name="RegexpSingleline">
+        <property name="format" value="(class|interface) ([a-zA-Z0-9_])+(&lt;.*&gt;)? (extends|implements)" />
+        <property name="message" value="No new line before extends/implements" />
+    </module>
+
+    <module name="RegexpSingleline">
+        <property name="format" value="^import static .*\.(of|copyOf|valueOf);$" />
+        <property name="message" value="The following methods may not be statically imported: of, copyOf, valueOf" />
+    </module>
+    <module name="RegexpSingleline">
+        <property name="format" value="^import static .*\.(all|none);$" />
+        <property name="message" value="The following methods may not be statically imported: all, none" />
+    </module>
+    <module name="RegexpSingleline">
+        <property name="format" value="^import static (?!java\.lang\.String\.format;).*\.format;" />
+        <property name="message" value="Only 'format' from java.lang.String may be statically imported" />
+    </module>
+    <module name="RegexpSingleline">
+        <property name="format" value="^import static java\.util\.Optional\." />
+        <property name="message" value="Members of Optional may not be statically imported" />
+    </module>
+
+    <module name="RegexpSingleline">
+        <property name="format" value="^([^i]|i[^m]|im[^p]|imp[^o]|impo[^r]|impor[^t]|import[^ ]).*Objects\.requireNonNull" />
+        <property name="message" value="Objects.requireNonNull should only be used with static imports" />
+    </module>
+    <module name="RegexpSingleline">
+        <property name="format" value="^([^i]|i[^m]|im[^p]|imp[^o]|impo[^r]|impor[^t]|import[^ ]).*Math\.toIntExact" />
+        <property name="message" value="Math.toIntExact should only be used with static imports" />
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="^[ \t]*import org\.testng\.Assert;$" />
+        <property name="message" value="org.testng.Assert should only be used with static imports" />
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="^[ \t]*import com\.google\.common\.base\.MoreObjects;$" />
+        <property name="message" value="com.google.common.base.MoreObjects should only be used with static imports" />
+    </module>
+
+    <module name="RegexpMultiline">
+        <property name="format" value="^[ \t]*import org\.jetbrains\.annotations\.NotNull;$" />
+        <property name="message" value="Not null is the default for the codebase and should not be annotated" />
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="^[ \t]*import org\.jetbrains\.annotations\.Nullable;$" />
+        <property name="message" value="Use javax.annotation.Nullable instead of org.jetbrains.annotations.Nullable" />
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="^[ \t]*import static org\.testng\.AssertJUnit\." />
+        <property name="message" value="Use org.testng.Assert instead of org.testng.AssertJUnit" />
+    </module>
+
+    <module name="SuppressWarningsFilter" />
+
+    <module name="TreeWalker">
+        <module name="SuppressWarningsHolder" />
+
+        <module name="EmptyBlock">
+            <property name="option" value="text" />
+            <property name="tokens" value="
+                LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_IF,
+                LITERAL_FOR, LITERAL_TRY, LITERAL_WHILE, INSTANCE_INIT, STATIC_INIT" />
+        </module>
+        <module name="EmptyStatement" />
+        <module name="EmptyForInitializerPad" />
+        <module name="EmptyForIteratorPad">
+            <property name="option" value="space" />
+        </module>
+        <module name="MethodParamPad">
+            <property name="allowLineBreaks" value="true" />
+            <property name="option" value="nospace" />
+        </module>
+        <module name="ParenPad" />
+        <module name="TypecastParenPad" />
+        <module name="NeedBraces" />
+        <module name="LeftCurly">
+            <property name="option" value="nl" />
+            <property name="tokens" value="CLASS_DEF, CTOR_DEF, INTERFACE_DEF, METHOD_DEF" />
+        </module>
+        <module name="LeftCurly">
+            <property name="option" value="eol" />
+            <property name="tokens" value="
+                 LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR,
+                 LITERAL_IF, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE" />
+        </module>
+        <module name="RightCurly">
+            <property name="option" value="alone" />
+        </module>
+        <module name="GenericWhitespace" />
+        <module name="WhitespaceAfter" />
+        <module name="NoWhitespaceAfter" />
+        <module name="NoWhitespaceBefore" />
+        <module name="SingleSpaceSeparator" />
+        <module name="Indentation">
+            <property name="throwsIndent" value="8" />
+            <property name="lineWrappingIndentation" value="8" />
+        </module>
+
+        <module name="UpperEll" />
+        <module name="DefaultComesLast" />
+        <module name="ArrayTypeStyle" />
+        <module name="MultipleVariableDeclarations" />
+        <module name="ModifierOrder" />
+        <module name="OneStatementPerLine" />
+        <module name="StringLiteralEquality" />
+        <module name="MutableException" />
+        <module name="EqualsHashCode" />
+        <module name="InnerAssignment" />
+        <module name="InterfaceIsType" />
+        <module name="HideUtilityClassConstructor" />
+        <module name="ExplicitInitialization" />
+        <module name="OneTopLevelClass" />
+
+        <module name="MemberName" />
+        <module name="LocalVariableName" />
+        <module name="LocalFinalVariableName" />
+        <module name="TypeName" />
+        <module name="PackageName" />
+        <module name="ParameterName" />
+        <module name="StaticVariableName" />
+        <module name="ClassTypeParameterName">
+            <property name="format" value="^[A-Z][0-9]?$" />
+        </module>
+        <module name="MethodTypeParameterName">
+            <property name="format" value="^[A-Z][0-9]?$" />
+        </module>
+
+        <module name="AnnotationUseStyle">
+            <property name="trailingArrayComma" value="ignore" />
+        </module>
+
+        <module name="AvoidStarImport" />
+        <module name="RedundantImport" />
+        <module name="UnusedImports" />
+        <module name="ImportOrder">
+            <property name="groups" value="*,javax,java" />
+            <property name="separated" value="true" />
+            <property name="option" value="bottom" />
+            <property name="sortStaticImportsAlphabetically" value="true" />
+        </module>
+
+        <module name="WhitespaceAround">
+            <property name="allowEmptyConstructors" value="true" />
+            <property name="allowEmptyMethods" value="true" />
+            <property name="allowEmptyLambdas" value="true" />
+            <property name="ignoreEnhancedForColon" value="false" />
+            <property name="tokens" value="
+                ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN,
+                BXOR, BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAND,
+                LAMBDA, LE, LITERAL_ASSERT, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE,
+                LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_RETURN, LITERAL_SWITCH,
+                LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE,
+                LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN, NOT_EQUAL,
+                PLUS, PLUS_ASSIGN, QUESTION, SL, SLIST, SL_ASSIGN, SR, SR_ASSIGN,
+                STAR, STAR_ASSIGN, TYPE_EXTENSION_AND" />
+        </module>
+
+        <module name="WhitespaceAfter" />
+
+        <module name="NoWhitespaceAfter">
+            <property name="tokens" value="DOT" />
+            <property name="allowLineBreaks" value="false" />
+        </module>
+
+        <module name="IllegalImport">
+            <property name="illegalPkgs" value="org.weakref.jmx.internal" />
+            <property name="illegalPkgs" value="jersey.repackaged" />
+            <property name="illegalPkgs" value="jdk.nashorn.internal" />
+            <property name="illegalPkgs" value="jdk.internal" />
+            <!-- Added to avoid accidental imports of the Spark shaded guava library that lives under the org.spark_project.guava package -->
+            <!-- It seems unlikely that anything would need to be imported from the org.spark_project package, as it contains private or semi private API -->
+            <property name="illegalPkgs" value="org.spark_project" />
+        </module>
+
+        <module name="IllegalImport">
+            <property name="illegalPkgs" value=".*\.\$internal" />
+            <property name="regexp" value="true" />
+        </module>
+    </module>
+</module>

--- a/src/main/java/com/facebook/presto/elasticsearch/AwsSecurityConfig.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/AwsSecurityConfig.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.facebook.airlift.configuration.Config;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.Optional;
+
+public class AwsSecurityConfig
+{
+    private String accessKey;
+    private String secretKey;
+    private boolean useAwsInstanceCredentials;
+    private String region;
+
+    @NotNull
+    public Optional<String> getAccessKey()
+    {
+        return Optional.ofNullable(accessKey);
+    }
+
+    @Config("elasticsearch.aws.access-key")
+    public AwsSecurityConfig setAccessKey(String key)
+    {
+        this.accessKey = key;
+        return this;
+    }
+
+    @NotNull
+    public Optional<String> getSecretKey()
+    {
+        return Optional.ofNullable(secretKey);
+    }
+
+    @Config("elasticsearch.aws.secret-key")
+    public AwsSecurityConfig setSecretKey(String key)
+    {
+        this.secretKey = key;
+        return this;
+    }
+
+    public boolean isUseInstanceCredentials()
+    {
+        return useAwsInstanceCredentials;
+    }
+
+    @Config("elasticsearch.aws.use-instance-credentials")
+    public AwsSecurityConfig setUseInstanceCredentials(boolean use)
+    {
+        this.useAwsInstanceCredentials = use;
+        return this;
+    }
+
+    public String getRegion()
+    {
+        return region;
+    }
+
+    @Config("elasticsearch.aws.region")
+    public AwsSecurityConfig setRegion(String region)
+    {
+        this.region = region;
+        return this;
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/BuiltinColumns.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/BuiltinColumns.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ColumnMetadata;
+
+import java.util.Arrays;
+import java.util.Set;
+
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+
+enum BuiltinColumns
+{
+    ID("_id", VARCHAR, true),
+    SOURCE("_source", VARCHAR, false),
+    SCORE("_score", REAL, false);
+
+    public static final Set<String> NAMES = Arrays.stream(values())
+            .map(BuiltinColumns::getName)
+            .collect(toImmutableSet());
+
+    private final String name;
+    private final Type type;
+    private final boolean supportsPredicates;
+
+    BuiltinColumns(String name, Type type, boolean supportsPredicates)
+    {
+        this.name = name;
+        this.type = type;
+        this.supportsPredicates = supportsPredicates;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public Type getType()
+    {
+        return type;
+    }
+
+    public ColumnMetadata getMetadata()
+    {
+        return new ColumnMetadata(name, type, "", null, true);
+    }
+
+    public ColumnHandle getColumnHandle()
+    {
+        return new ElasticsearchColumnHandle(name, type, supportsPredicates);
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/CountQueryPageSource.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/CountQueryPageSource.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.elasticsearch.client.ElasticsearchClient;
+import com.facebook.presto.spi.ConnectorPageSource;
+import com.facebook.presto.spi.ConnectorSession;
+
+import static com.facebook.presto.elasticsearch.ElasticsearchQueryBuilder.buildSearchQuery;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+
+public class CountQueryPageSource
+        implements ConnectorPageSource
+{
+    // This implementation of the page source is used whenever a query doesn't reference any columns
+    // from the ES table. We need to limit the number of rows per page in case there are projections
+    // in the query that can cause page sizes to explode. For example: SELECT rand() FROM some_table
+    private static final int BATCH_SIZE = 10000;
+
+    private final long readTimeNanos;
+    private long remaining;
+
+    public CountQueryPageSource(ElasticsearchClient client, ConnectorSession session, ElasticsearchTableHandle table, ElasticsearchSplit split)
+    {
+        requireNonNull(client, "client is null");
+        requireNonNull(session, "session is null");
+        requireNonNull(table, "table is null");
+        requireNonNull(split, "split is null");
+
+        long start = System.nanoTime();
+        long count = client.count(
+                split.getIndex(),
+                split.getShard(),
+                buildSearchQuery(session, split.getTupleDomain().transform(ElasticsearchColumnHandle.class::cast), table.getQuery()));
+
+        readTimeNanos = System.nanoTime() - start;
+        remaining = count;
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return remaining == 0;
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        int batch = toIntExact(Math.min(BATCH_SIZE, remaining));
+        remaining -= batch;
+
+        return new Page(batch);
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return readTimeNanos;
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getCompletedPositions()
+    {
+        return BATCH_SIZE;
+    }
+
+    @Override
+    public long getSystemMemoryUsage()
+    {
+        return 0;
+    }
+
+    @Override
+    public void close()
+    {
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/Elasticsearch6Plugin.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/Elasticsearch6Plugin.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.connector.ConnectorFactory;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+
+import static java.util.Objects.requireNonNull;
+
+public class Elasticsearch6Plugin
+        implements Plugin
+{
+    private final ConnectorFactory connectorFactory;
+
+    public Elasticsearch6Plugin()
+    {
+        connectorFactory = new ElasticsearchConnectorFactory();
+    }
+
+    @VisibleForTesting
+    Elasticsearch6Plugin(ElasticsearchConnectorFactory factory)
+    {
+        connectorFactory = requireNonNull(factory, "factory is null");
+    }
+
+    @Override
+    public synchronized Iterable<ConnectorFactory> getConnectorFactories()
+    {
+        return ImmutableList.of(connectorFactory);
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchColumn.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchColumn.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.facebook.presto.common.type.Type;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Objects.requireNonNull;
+
+public final class ElasticsearchColumn
+{
+    private final String name;
+    private final Type type;
+    private final String jsonPath;
+    private final String jsonType;
+    private final int ordinalPosition;
+
+    @JsonCreator
+    public ElasticsearchColumn(
+            @JsonProperty("name") String name,
+            @JsonProperty("type") Type type,
+            @JsonProperty("jsonPath") String jsonPath,
+            @JsonProperty("jsonType") String jsonType,
+            @JsonProperty("ordinalPosition") int ordinalPosition)
+    {
+        checkArgument(!isNullOrEmpty(name), "name is null or empty");
+        this.name = name;
+        this.type = requireNonNull(type, "type is null");
+        this.jsonPath = requireNonNull(jsonPath, "jsonPath is null");
+        this.jsonType = requireNonNull(jsonType, "jsonType is null");
+        this.ordinalPosition = ordinalPosition;
+    }
+
+    @JsonProperty
+    public String getName()
+    {
+        return name;
+    }
+
+    @JsonProperty
+    public Type getType()
+    {
+        return type;
+    }
+
+    @JsonProperty
+    public String getJsonPath()
+    {
+        return jsonPath;
+    }
+
+    @JsonProperty
+    public String getJsonType()
+    {
+        return jsonType;
+    }
+
+    @JsonProperty
+    public int getOrdinalPosition()
+    {
+        return ordinalPosition;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name, type, jsonPath, jsonType, ordinalPosition);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        ElasticsearchColumn other = (ElasticsearchColumn) obj;
+        return Objects.equals(this.name, other.name) &&
+                Objects.equals(this.type, other.type) &&
+                Objects.equals(this.jsonPath, other.jsonPath) &&
+                Objects.equals(this.jsonType, other.jsonType) &&
+                Objects.equals(this.ordinalPosition, other.ordinalPosition);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("name", name)
+                .add("type", type)
+                .add("jsonPath", jsonPath)
+                .add("jsonType", jsonType)
+                .add("ordinalPosition", ordinalPosition)
+                .toString();
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchColumnHandle.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchColumnHandle.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.ColumnHandle;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public final class ElasticsearchColumnHandle
+        implements ColumnHandle
+{
+    private final String name;
+    private final Type type;
+    private final boolean supportsPredicates;
+
+    @JsonCreator
+    public ElasticsearchColumnHandle(
+            @JsonProperty("name") String name,
+            @JsonProperty("type") Type type,
+            @JsonProperty("supportsPredicates") boolean supportsPredicates)
+    {
+        this.name = requireNonNull(name, "name is null");
+        this.type = requireNonNull(type, "type is null");
+        this.supportsPredicates = supportsPredicates;
+    }
+
+    @JsonProperty
+    public String getName()
+    {
+        return name;
+    }
+
+    @JsonProperty
+    public Type getType()
+    {
+        return type;
+    }
+
+    @JsonProperty
+    public boolean isSupportsPredicates()
+    {
+        return supportsPredicates;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name, type, supportsPredicates);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+
+        ElasticsearchColumnHandle other = (ElasticsearchColumnHandle) obj;
+        return this.supportsPredicates == other.supportsPredicates &&
+                Objects.equals(this.getName(), other.getName()) &&
+                Objects.equals(this.getType(), other.getType());
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("name", getName())
+                .add("type", getType())
+                .toString();
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchConfig.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchConfig.java
@@ -1,0 +1,327 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
+import com.facebook.airlift.configuration.ConfigSecuritySensitive;
+import io.airlift.units.Duration;
+import io.airlift.units.MinDuration;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+import java.io.File;
+import java.util.Optional;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class ElasticsearchConfig
+{
+    public enum Security
+    {
+        AWS,
+        PASSWORD
+    }
+
+    private String host;
+    private int port = 9200;
+    private String defaultSchema = "default";
+    private int scrollSize = 1_000;
+    private Duration scrollTimeout = new Duration(1, MINUTES);
+    private int maxHits = 1_000;
+    private Duration requestTimeout = new Duration(10, SECONDS);
+    private Duration connectTimeout = new Duration(1, SECONDS);
+    private Duration maxRetryTime = new Duration(30, SECONDS);
+    private Duration nodeRefreshInterval = new Duration(1, MINUTES);
+    private int maxHttpConnections = 25;
+    private int httpThreadCount = Runtime.getRuntime().availableProcessors();
+
+    private boolean tlsEnabled;
+    private File keystorePath;
+    private File trustStorePath;
+    private String keystorePassword;
+    private String truststorePassword;
+    private boolean ignorePublishAddress;
+    private boolean verifyHostnames = true;
+    private Security security;
+
+    @NotNull
+    public String getHost()
+    {
+        return host;
+    }
+
+    @Config("elasticsearch.host")
+    public ElasticsearchConfig setHost(String host)
+    {
+        this.host = host;
+        return this;
+    }
+
+    public int getPort()
+    {
+        return port;
+    }
+
+    @Config("elasticsearch.port")
+    public ElasticsearchConfig setPort(int port)
+    {
+        this.port = port;
+        return this;
+    }
+
+    @NotNull
+    public String getDefaultSchema()
+    {
+        return defaultSchema;
+    }
+
+    @Config("elasticsearch.default-schema-name")
+    @ConfigDescription("Default schema name to use")
+    public ElasticsearchConfig setDefaultSchema(String defaultSchema)
+    {
+        this.defaultSchema = defaultSchema;
+        return this;
+    }
+
+    @NotNull
+    @Min(1)
+    public int getScrollSize()
+    {
+        return scrollSize;
+    }
+
+    @Config("elasticsearch.scroll-size")
+    @ConfigDescription("Scroll batch size")
+    public ElasticsearchConfig setScrollSize(int scrollSize)
+    {
+        this.scrollSize = scrollSize;
+        return this;
+    }
+
+    @NotNull
+    public Duration getScrollTimeout()
+    {
+        return scrollTimeout;
+    }
+
+    @Config("elasticsearch.scroll-timeout")
+    @ConfigDescription("Scroll timeout")
+    public ElasticsearchConfig setScrollTimeout(Duration scrollTimeout)
+    {
+        this.scrollTimeout = scrollTimeout;
+        return this;
+    }
+
+    @NotNull
+    @Min(1)
+    public int getMaxHits()
+    {
+        return maxHits;
+    }
+
+    @Config("elasticsearch.max-hits")
+    @ConfigDescription("Max number of hits a single Elasticsearch request can fetch")
+    public ElasticsearchConfig setMaxHits(int maxHits)
+    {
+        this.maxHits = maxHits;
+        return this;
+    }
+
+    @NotNull
+    public Duration getRequestTimeout()
+    {
+        return requestTimeout;
+    }
+
+    @Config("elasticsearch.request-timeout")
+    @ConfigDescription("Elasticsearch request timeout")
+    public ElasticsearchConfig setRequestTimeout(Duration requestTimeout)
+    {
+        this.requestTimeout = requestTimeout;
+        return this;
+    }
+
+    @NotNull
+    public Duration getConnectTimeout()
+    {
+        return connectTimeout;
+    }
+
+    @Config("elasticsearch.connect-timeout")
+    @ConfigDescription("Elasticsearch connect timeout")
+    public ElasticsearchConfig setConnectTimeout(Duration timeout)
+    {
+        this.connectTimeout = timeout;
+        return this;
+    }
+
+    @NotNull
+    public Duration getMaxRetryTime()
+    {
+        return maxRetryTime;
+    }
+
+    @Config("elasticsearch.max-retry-time")
+    @ConfigDescription("Maximum timeout in case of multiple retries")
+    public ElasticsearchConfig setMaxRetryTime(Duration maxRetryTime)
+    {
+        this.maxRetryTime = maxRetryTime;
+        return this;
+    }
+
+    @NotNull
+    @MinDuration("1ms")
+    public Duration getNodeRefreshInterval()
+    {
+        return nodeRefreshInterval;
+    }
+
+    @Config("elasticsearch.node-refresh-interval")
+    @ConfigDescription("How often to refresh the list of available Elasticsearch nodes")
+    public ElasticsearchConfig setNodeRefreshInterval(Duration nodeRefreshInterval)
+    {
+        this.nodeRefreshInterval = nodeRefreshInterval;
+        return this;
+    }
+
+    @Config("elasticsearch.max-http-connections")
+    @ConfigDescription("Maximum number of persistent HTTP connections to Elasticsearch")
+    public ElasticsearchConfig setMaxHttpConnections(int maxHttpConnections)
+    {
+        this.maxHttpConnections = maxHttpConnections;
+        return this;
+    }
+
+    @NotNull
+    public int getMaxHttpConnections()
+    {
+        return maxHttpConnections;
+    }
+
+    @Config("elasticsearch.http-thread-count")
+    @ConfigDescription("Number of threads handling HTTP connections to Elasticsearch")
+    public ElasticsearchConfig setHttpThreadCount(int httpThreadCount)
+    {
+        this.httpThreadCount = httpThreadCount;
+        return this;
+    }
+
+    @NotNull
+    public int getHttpThreadCount()
+    {
+        return httpThreadCount;
+    }
+
+    public boolean isTlsEnabled()
+    {
+        return tlsEnabled;
+    }
+
+    @Config("elasticsearch.tls.enabled")
+    public ElasticsearchConfig setTlsEnabled(boolean tlsEnabled)
+    {
+        this.tlsEnabled = tlsEnabled;
+        return this;
+    }
+
+    public Optional<File> getKeystorePath()
+    {
+        return Optional.ofNullable(keystorePath);
+    }
+
+    @Config("elasticsearch.tls.keystore-path")
+    public ElasticsearchConfig setKeystorePath(File path)
+    {
+        this.keystorePath = path;
+        return this;
+    }
+
+    public Optional<String> getKeystorePassword()
+    {
+        return Optional.ofNullable(keystorePassword);
+    }
+
+    @Config("elasticsearch.tls.keystore-password")
+    @ConfigSecuritySensitive
+    public ElasticsearchConfig setKeystorePassword(String password)
+    {
+        this.keystorePassword = password;
+        return this;
+    }
+
+    public Optional<File> getTrustStorePath()
+    {
+        return Optional.ofNullable(trustStorePath);
+    }
+
+    @Config("elasticsearch.tls.truststore-path")
+    public ElasticsearchConfig setTrustStorePath(File path)
+    {
+        this.trustStorePath = path;
+        return this;
+    }
+
+    public Optional<String> getTruststorePassword()
+    {
+        return Optional.ofNullable(truststorePassword);
+    }
+
+    @Config("elasticsearch.tls.truststore-password")
+    @ConfigSecuritySensitive
+    public ElasticsearchConfig setTruststorePassword(String password)
+    {
+        this.truststorePassword = password;
+        return this;
+    }
+
+    public boolean isVerifyHostnames()
+    {
+        return verifyHostnames;
+    }
+
+    @Config("elasticsearch.tls.verify-hostnames")
+    public ElasticsearchConfig setVerifyHostnames(boolean verify)
+    {
+        this.verifyHostnames = verify;
+        return this;
+    }
+
+    public boolean isIgnorePublishAddress()
+    {
+        return ignorePublishAddress;
+    }
+
+    @Config("elasticsearch.ignore-publish-address")
+    public ElasticsearchConfig setIgnorePublishAddress(boolean ignorePublishAddress)
+    {
+        this.ignorePublishAddress = ignorePublishAddress;
+        return this;
+    }
+
+    @NotNull
+    public Optional<Security> getSecurity()
+    {
+        return Optional.ofNullable(security);
+    }
+
+    @Config("elasticsearch.security")
+    public ElasticsearchConfig setSecurity(Security security)
+    {
+        this.security = security;
+        return this;
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchConnector.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchConnector.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.facebook.airlift.bootstrap.LifeCycleManager;
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.spi.SystemTable;
+import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
+import com.facebook.presto.spi.connector.ConnectorSplitManager;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.transaction.IsolationLevel;
+import com.google.common.collect.ImmutableSet;
+
+import javax.inject.Inject;
+
+import java.util.Set;
+
+import static com.facebook.presto.spi.transaction.IsolationLevel.READ_COMMITTED;
+import static com.facebook.presto.spi.transaction.IsolationLevel.checkConnectorSupports;
+import static java.util.Objects.requireNonNull;
+
+public class ElasticsearchConnector
+        implements Connector
+{
+    private static final Logger LOG = Logger.get(ElasticsearchConnector.class);
+
+    private final LifeCycleManager lifeCycleManager;
+    private final ElasticsearchMetadata metadata;
+    private final ElasticsearchSplitManager splitManager;
+    private final ElasticsearchPageSourceProvider pageSourceProvider;
+    private final NodesSystemTable nodesSystemTable;
+
+    @Inject
+    public ElasticsearchConnector(
+            LifeCycleManager lifeCycleManager,
+            ElasticsearchMetadata metadata,
+            ElasticsearchSplitManager splitManager,
+            ElasticsearchPageSourceProvider pageSourceProvider,
+            NodesSystemTable nodesSystemTable)
+    {
+        this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.splitManager = requireNonNull(splitManager, "splitManager is null");
+        this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
+        this.nodesSystemTable = requireNonNull(nodesSystemTable, "nodesSystemTable is null");
+    }
+
+    @Override
+    public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly)
+    {
+        checkConnectorSupports(READ_COMMITTED, isolationLevel);
+        return ElasticsearchTransactionHandle.INSTANCE;
+    }
+
+    @Override
+    public ConnectorMetadata getMetadata(ConnectorTransactionHandle transactionHandle)
+    {
+        return metadata;
+    }
+
+    @Override
+    public ConnectorSplitManager getSplitManager()
+    {
+        return splitManager;
+    }
+
+    @Override
+    public ConnectorPageSourceProvider getPageSourceProvider()
+    {
+        return pageSourceProvider;
+    }
+
+    @Override
+    public Set<SystemTable> getSystemTables()
+    {
+        return ImmutableSet.of(nodesSystemTable);
+    }
+
+    @Override
+    public final void shutdown()
+    {
+        try {
+            lifeCycleManager.stop();
+        }
+        catch (Exception e) {
+            LOG.error(e, "Error shutting down connector");
+        }
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchConnectorFactory.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchConnectorFactory.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.airlift.json.JsonModule;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.spi.ConnectorHandleResolver;
+import com.facebook.presto.spi.NodeManager;
+import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorContext;
+import com.facebook.presto.spi.connector.ConnectorFactory;
+import com.google.inject.Injector;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public class ElasticsearchConnectorFactory
+        implements ConnectorFactory
+{
+    ElasticsearchConnectorFactory() {}
+
+    @Override
+    public String getName()
+    {
+        return "elasticsearch_6";
+    }
+
+    @Override
+    public ConnectorHandleResolver getHandleResolver()
+    {
+        return new ElasticsearchHandleResolver();
+    }
+
+    @Override
+    public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
+    {
+        requireNonNull(catalogName, "catalogName is null");
+        requireNonNull(config, "config is null");
+
+        try {
+            Bootstrap app = new Bootstrap(
+                    new JsonModule(),
+                    new ElasticsearchConnectorModule(),
+                    binder -> {
+                        binder.bind(TypeManager.class).toInstance(context.getTypeManager());
+                        binder.bind(NodeManager.class).toInstance(context.getNodeManager());
+                    });
+
+            Injector injector = app
+                    .doNotInitializeLogging()
+                    .setRequiredConfigurationProperties(config)
+                    .initialize();
+
+            return injector.getInstance(ElasticsearchConnector.class);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchConnectorModule.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchConnectorModule.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.facebook.airlift.configuration.AbstractConfigurationAwareModule;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.decoder.DecoderModule;
+import com.facebook.presto.elasticsearch.client.ElasticsearchClient;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.FromStringDeserializer;
+import com.google.inject.Binder;
+import com.google.inject.Scopes;
+
+import javax.inject.Inject;
+
+import static com.facebook.airlift.configuration.ConditionalModule.installModuleIf;
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static com.facebook.airlift.json.JsonBinder.jsonBinder;
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.elasticsearch.ElasticsearchConfig.Security.AWS;
+import static com.facebook.presto.elasticsearch.ElasticsearchConfig.Security.PASSWORD;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
+import static java.util.Objects.requireNonNull;
+import static java.util.function.Predicate.isEqual;
+
+public class ElasticsearchConnectorModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        binder.bind(ElasticsearchConnector.class).in(Scopes.SINGLETON);
+        binder.bind(ElasticsearchMetadata.class).in(Scopes.SINGLETON);
+        binder.bind(ElasticsearchSplitManager.class).in(Scopes.SINGLETON);
+        binder.bind(ElasticsearchPageSourceProvider.class).in(Scopes.SINGLETON);
+        binder.bind(ElasticsearchClient.class).in(Scopes.SINGLETON);
+        binder.bind(NodesSystemTable.class).in(Scopes.SINGLETON);
+
+        configBinder(binder).bindConfig(ElasticsearchConfig.class);
+
+        jsonBinder(binder).addDeserializerBinding(Type.class).to(TypeDeserializer.class);
+
+        binder.install(new DecoderModule());
+
+        newOptionalBinder(binder, AwsSecurityConfig.class);
+        newOptionalBinder(binder, PasswordConfig.class);
+
+        install(installModuleIf(
+                ElasticsearchConfig.class,
+                config -> config.getSecurity()
+                        .filter(isEqual(AWS))
+                        .isPresent(),
+                conditionalBinder -> configBinder(conditionalBinder).bindConfig(AwsSecurityConfig.class)));
+
+        install(installModuleIf(
+                ElasticsearchConfig.class,
+                config -> config.getSecurity()
+                        .filter(isEqual(PASSWORD))
+                        .isPresent(),
+                conditionalBinder -> configBinder(conditionalBinder).bindConfig(PasswordConfig.class)));
+    }
+
+    private static final class TypeDeserializer
+            extends FromStringDeserializer<Type>
+    {
+        private static final long serialVersionUID = 1L;
+
+        private final TypeManager typeManager;
+
+        @Inject
+        public TypeDeserializer(TypeManager typeManager)
+        {
+            super(Type.class);
+            this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        }
+
+        @Override
+        protected Type _deserialize(String value, DeserializationContext context)
+        {
+            Type type = typeManager.getType(parseTypeSignature(value));
+            checkArgument(type != null, "Unknown type %s", value);
+            return type;
+        }
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchErrorCode.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchErrorCode.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.facebook.presto.common.ErrorCode;
+import com.facebook.presto.common.ErrorType;
+import com.facebook.presto.spi.ErrorCodeSupplier;
+
+import static com.facebook.presto.common.ErrorType.EXTERNAL;
+
+public enum ElasticsearchErrorCode
+        implements ErrorCodeSupplier
+{
+    ELASTICSEARCH_CONNECTION_ERROR(0, EXTERNAL),
+    ELASTICSEARCH_INVALID_RESPONSE(1, EXTERNAL),
+    ELASTICSEARCH_SSL_INITIALIZATION_FAILURE(2, EXTERNAL),
+    ELASTICSEARCH_MAX_HITS_EXCEEDED(3, EXTERNAL),
+    ELASTICSEARCH_TYPE_MISMATCH(4, EXTERNAL),
+    ELASTICSEARCH_QUERY_FAILURE(5, EXTERNAL);
+
+    private final ErrorCode errorCode;
+
+    ElasticsearchErrorCode(int code, ErrorType type)
+    {
+        errorCode = new ErrorCode(code + 0x0503_0000, name(), type);
+    }
+
+    @Override
+    public ErrorCode toErrorCode()
+    {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchHandleResolver.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchHandleResolver.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorHandleResolver;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+
+public class ElasticsearchHandleResolver
+        implements ConnectorHandleResolver
+{
+    @Override
+    public Class<? extends ConnectorTableHandle> getTableHandleClass()
+    {
+        return ElasticsearchTableHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorTableLayoutHandle> getTableLayoutHandleClass()
+    {
+        return ElasticsearchTableLayoutHandle.class;
+    }
+
+    @Override
+    public Class<? extends ColumnHandle> getColumnHandleClass()
+    {
+        return ElasticsearchColumnHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorSplit> getSplitClass()
+    {
+        return ElasticsearchSplit.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorTransactionHandle> getTransactionHandleClass()
+    {
+        return ElasticsearchTransactionHandle.class;
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchMetadata.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchMetadata.java
@@ -1,0 +1,454 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.facebook.airlift.json.JsonObjectMapperProvider;
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.elasticsearch.client.ElasticsearchClient;
+import com.facebook.presto.elasticsearch.client.IndexMetadata;
+import com.facebook.presto.elasticsearch.client.IndexMetadata.DateTimeType;
+import com.facebook.presto.elasticsearch.client.IndexMetadata.ObjectType;
+import com.facebook.presto.elasticsearch.client.IndexMetadata.PrimitiveType;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.ConnectorTableLayout;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.ConnectorTableLayoutResult;
+import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.Constraint;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.SchemaTablePrefix;
+import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.BaseEncoding;
+
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.RowType.Field;
+import static com.facebook.presto.common.type.SmallintType.SMALLINT;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TinyintType.TINYINT;
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.elasticsearch.ElasticsearchTableHandle.Type.QUERY;
+import static com.facebook.presto.elasticsearch.ElasticsearchTableHandle.Type.SCAN;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_ARGUMENTS;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+
+public class ElasticsearchMetadata
+        implements ConnectorMetadata
+{
+    private static final Logger log = Logger.get(ElasticsearchMetadata.class);
+    private static final ObjectMapper JSON_PARSER = new JsonObjectMapperProvider().get();
+
+    private static final String PASSTHROUGH_QUERY_SUFFIX = "$query";
+    private final Map<String, ColumnHandle> queryTableColumns;
+    private final ColumnMetadata queryResultColumnMetadata;
+
+    private final ElasticsearchClient client;
+    private final String schemaName;
+    private final Type ipAddressType;
+
+    @Inject
+    public ElasticsearchMetadata(TypeManager typeManager, ElasticsearchClient client, ElasticsearchConfig config)
+    {
+        requireNonNull(config, "config is null");
+        this.ipAddressType = typeManager.getType(new TypeSignature(StandardTypes.IPADDRESS));
+        this.client = requireNonNull(client, "client is null");
+        requireNonNull(config, "config is null");
+        this.schemaName = config.getDefaultSchema();
+
+        Type jsonType = typeManager.getType(new TypeSignature(StandardTypes.JSON));
+        queryResultColumnMetadata = ColumnMetadata.builder()
+                .setName("result")
+                .setType(jsonType)
+                .setNullable(true)
+                .setHidden(false)
+                .build();
+
+        queryTableColumns = ImmutableMap.of("result", new ElasticsearchColumnHandle("result", jsonType, false));
+    }
+
+    @Override
+    public List<String> listSchemaNames(ConnectorSession session)
+    {
+        return ImmutableList.of(schemaName);
+    }
+
+    @Override
+    public ElasticsearchTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName)
+    {
+        requireNonNull(tableName, "tableName is null");
+        if (tableName.getSchemaName().equals(schemaName)) {
+            String[] parts = tableName.getTableName().split(":", 2);
+            String table = parts[0];
+            Optional<String> query = Optional.empty();
+            ElasticsearchTableHandle.Type type = SCAN;
+            if (parts.length == 2) {
+                if (table.endsWith(PASSTHROUGH_QUERY_SUFFIX)) {
+                    table = table.substring(0, table.length() - PASSTHROUGH_QUERY_SUFFIX.length());
+                    byte[] decoded;
+                    try {
+                        decoded = BaseEncoding.base32().decode(parts[1].toUpperCase(ENGLISH));
+                    }
+                    catch (IllegalArgumentException e) {
+                        throw new PrestoException(INVALID_ARGUMENTS, format("Elasticsearch query for '%s' is not base32-encoded correctly", table), e);
+                    }
+
+                    String queryJson = new String(decoded, UTF_8);
+                    try {
+                        // Ensure this is valid json
+                        JSON_PARSER.readTree(queryJson);
+                    }
+                    catch (JsonProcessingException e) {
+                        throw new PrestoException(INVALID_ARGUMENTS, format("Elasticsearch query for '%s' is not valid JSON", table), e);
+                    }
+
+                    query = Optional.of(queryJson);
+                    type = QUERY;
+                }
+                else {
+                    query = Optional.of(parts[1]);
+                }
+            }
+
+            if (listTables(session, Optional.of(schemaName)).contains(new SchemaTableName(schemaName, table))) {
+                return new ElasticsearchTableHandle(type, schemaName, table, query);
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public List<ConnectorTableLayoutResult> getTableLayouts(ConnectorSession session, ConnectorTableHandle table, Constraint<ColumnHandle> constraint, Optional<Set<ColumnHandle>> desiredColumns)
+    {
+        ElasticsearchTableHandle handle = (ElasticsearchTableHandle) table;
+        ConnectorTableLayout layout = new ConnectorTableLayout(new ElasticsearchTableLayoutHandle(handle, constraint.getSummary()));
+        return ImmutableList.of(new ConnectorTableLayoutResult(layout, constraint.getSummary()));
+    }
+
+    @Override
+    public ConnectorTableLayout getTableLayout(ConnectorSession session, ConnectorTableLayoutHandle handle)
+    {
+        return new ConnectorTableLayout(handle);
+    }
+
+    @Override
+    public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table)
+    {
+        ElasticsearchTableHandle handle = (ElasticsearchTableHandle) table;
+
+        if (isPassthroughQuery(handle)) {
+            return new ConnectorTableMetadata(
+                    new SchemaTableName(handle.getSchema(), handle.getIndex()),
+                    ImmutableList.of(queryResultColumnMetadata));
+        }
+        return getTableMetadata(handle.getSchema(), handle.getIndex());
+    }
+
+    private ConnectorTableMetadata getTableMetadata(String schemaName, String tableName)
+    {
+        InternalTableMetadata internalTableMetadata = makeInternalTableMetadata(schemaName, tableName);
+        return new ConnectorTableMetadata(new SchemaTableName(schemaName, tableName), internalTableMetadata.getColumnMetadata());
+    }
+
+    private InternalTableMetadata makeInternalTableMetadata(ConnectorTableHandle table)
+    {
+        ElasticsearchTableHandle handle = (ElasticsearchTableHandle) table;
+        return makeInternalTableMetadata(handle.getSchema(), handle.getIndex());
+    }
+
+    private InternalTableMetadata makeInternalTableMetadata(String schema, String tableName)
+    {
+        IndexMetadata metadata = client.getIndexMetadata(tableName);
+        List<IndexMetadata.Field> fields = getColumnFields(metadata);
+        return new InternalTableMetadata(new SchemaTableName(schema, tableName), makeColumnMetadata(fields), makeColumnHandles(fields));
+    }
+
+    private List<IndexMetadata.Field> getColumnFields(IndexMetadata metadata)
+    {
+        ImmutableList.Builder<IndexMetadata.Field> result = ImmutableList.builder();
+
+        Map<String, Long> counts = metadata.getSchema()
+                .getFields().stream()
+                .collect(Collectors.groupingBy(f -> f.getName().toLowerCase(ENGLISH), Collectors.counting()));
+
+        for (IndexMetadata.Field field : metadata.getSchema().getFields()) {
+            Type type = toPrestoType(field);
+            if (type == null || counts.get(field.getName().toLowerCase(ENGLISH)) > 1) {
+                continue;
+            }
+            result.add(field);
+        }
+        return result.build();
+    }
+
+    private List<ColumnMetadata> makeColumnMetadata(List<IndexMetadata.Field> fields)
+    {
+        ImmutableList.Builder<ColumnMetadata> result = ImmutableList.builder();
+
+        for (BuiltinColumns builtinColumn : BuiltinColumns.values()) {
+            result.add(builtinColumn.getMetadata());
+        }
+
+        for (IndexMetadata.Field field : fields) {
+            result.add(new ColumnMetadata(field.getName(), toPrestoType(field)));
+        }
+        return result.build();
+    }
+
+    private Map<String, ColumnHandle> makeColumnHandles(List<IndexMetadata.Field> fields)
+    {
+        ImmutableMap.Builder<String, ColumnHandle> result = ImmutableMap.builder();
+        for (BuiltinColumns builtinColumn : BuiltinColumns.values()) {
+            result.put(builtinColumn.getName(), builtinColumn.getColumnHandle());
+        }
+
+        for (IndexMetadata.Field field : fields) {
+            result.put(field.getName(), new ElasticsearchColumnHandle(
+                    field.getName(),
+                    toPrestoType(field),
+                    supportsPredicates(field.getType())));
+        }
+        return result.build();
+    }
+
+    private static boolean supportsPredicates(IndexMetadata.Type type)
+    {
+        if (type instanceof DateTimeType) {
+            return true;
+        }
+
+        if (type instanceof PrimitiveType) {
+            switch (((PrimitiveType) type).getName().toLowerCase(ENGLISH)) {
+                case "boolean":
+                case "byte":
+                case "short":
+                case "integer":
+                case "long":
+                case "double":
+                case "float":
+                case "keyword":
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    private Type toPrestoType(IndexMetadata.Field metaDataField)
+    {
+        return toPrestoType(metaDataField, metaDataField.isArray());
+    }
+
+    private Type toPrestoType(IndexMetadata.Field metaDataField, boolean isArray)
+    {
+        IndexMetadata.Type type = metaDataField.getType();
+        if (isArray) {
+            Type elementType = toPrestoType(metaDataField, false);
+            return new ArrayType(elementType);
+        }
+        else if (type instanceof PrimitiveType) {
+            switch (((PrimitiveType) type).getName()) {
+                case "float":
+                    return REAL;
+                case "double":
+                    return DOUBLE;
+                case "byte":
+                    return TINYINT;
+                case "short":
+                    return SMALLINT;
+                case "integer":
+                    return INTEGER;
+                case "long":
+                    return BIGINT;
+                case "string":
+                case "text":
+                case "keyword":
+                    return VARCHAR;
+                case "boolean":
+                    return BOOLEAN;
+                case "binary":
+                    return VARBINARY;
+                case "ip":
+                    return ipAddressType;
+            }
+        }
+        else if (type instanceof DateTimeType) {
+            if (((DateTimeType) type).getFormats().isEmpty()) {
+                return TIMESTAMP;
+            }
+            // otherwise, skip -- we don't support custom formats, yet
+        }
+        else if (type instanceof ObjectType) {
+            ObjectType objectType = (ObjectType) type;
+
+            ImmutableList.Builder<Field> builder = ImmutableList.builder();
+            for (IndexMetadata.Field field : objectType.getFields()) {
+                Type prestoType = toPrestoType(field);
+                if (prestoType != null) {
+                    builder.add(RowType.field(field.getName(), prestoType));
+                }
+                else {
+                    log.warn("Type is not implemented: %s", field.getType());
+                }
+            }
+            List<Field> fields = builder.build();
+            if (!fields.isEmpty()) {
+                return RowType.from(fields);
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
+    {
+        if (schemaName.isPresent() && !schemaName.get().equals(this.schemaName)) {
+            return ImmutableList.of();
+        }
+
+        ImmutableList.Builder<SchemaTableName> result = ImmutableList.builder();
+        Set<String> indexes = ImmutableSet.copyOf(client.getIndexes());
+
+        indexes.stream()
+                .map(index -> new SchemaTableName(this.schemaName, index))
+                .forEach(result::add);
+
+        client.getAliases().entrySet().stream()
+                .filter(entry -> indexes.contains(entry.getKey()))
+                .flatMap(entry -> entry.getValue().stream()
+                        .map(alias -> new SchemaTableName(this.schemaName, alias)))
+                .distinct()
+                .forEach(result::add);
+
+        return result.build();
+    }
+
+    @Override
+    public Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        ElasticsearchTableHandle table = (ElasticsearchTableHandle) tableHandle;
+
+        if (isPassthroughQuery(table)) {
+            return queryTableColumns;
+        }
+
+        InternalTableMetadata tableMetadata = makeInternalTableMetadata(tableHandle);
+        return tableMetadata.getColumnHandles();
+    }
+
+    @Override
+    public ColumnMetadata getColumnMetadata(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle)
+    {
+        ElasticsearchTableHandle table = (ElasticsearchTableHandle) tableHandle;
+        ElasticsearchColumnHandle column = (ElasticsearchColumnHandle) columnHandle;
+
+        if (isPassthroughQuery(table)) {
+            if (column.getName().equals(queryResultColumnMetadata.getName())) {
+                return queryResultColumnMetadata;
+            }
+
+            throw new IllegalArgumentException(format("Unexpected column for table '%s$query': %s", table.getIndex(), column.getName()));
+        }
+
+        return ColumnMetadata.builder()
+                .setName(column.getName())
+                .setType(column.getType())
+                .build();
+    }
+
+    private static boolean isPassthroughQuery(ElasticsearchTableHandle table)
+    {
+        return table.getType().equals(QUERY);
+    }
+
+    @Override
+    public Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(ConnectorSession session, SchemaTablePrefix prefix)
+    {
+        if (prefix.getSchemaName() != null && !prefix.getSchemaName().equals(schemaName)) {
+            return ImmutableMap.of();
+        }
+
+        if (prefix.getSchemaName() != null && prefix.getTableName() != null) {
+            ConnectorTableMetadata metadata = getTableMetadata(prefix.getSchemaName(), prefix.getTableName());
+            return ImmutableMap.of(metadata.getTable(), metadata.getColumns());
+        }
+
+        return listTables(session, prefix.getSchemaName()).stream()
+                .map(name -> getTableMetadata(name.getSchemaName(), name.getTableName()))
+                .collect(toImmutableMap(ConnectorTableMetadata::getTable, ConnectorTableMetadata::getColumns));
+    }
+
+    private static class InternalTableMetadata
+    {
+        private final SchemaTableName tableName;
+        private final List<ColumnMetadata> columnMetadata;
+        private final Map<String, ColumnHandle> columnHandles;
+
+        public InternalTableMetadata(
+                SchemaTableName tableName,
+                List<ColumnMetadata> columnMetadata,
+                Map<String, ColumnHandle> columnHandles)
+        {
+            this.tableName = tableName;
+            this.columnMetadata = columnMetadata;
+            this.columnHandles = columnHandles;
+        }
+
+        public SchemaTableName getTableName()
+        {
+            return tableName;
+        }
+
+        public List<ColumnMetadata> getColumnMetadata()
+        {
+            return columnMetadata;
+        }
+
+        public Map<String, ColumnHandle> getColumnHandles()
+        {
+            return columnHandles;
+        }
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchPageSourceProvider.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchPageSourceProvider.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.elasticsearch.client.ElasticsearchClient;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorPageSource;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.SplitContext;
+import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+
+import javax.inject.Inject;
+
+import java.util.List;
+
+import static com.facebook.presto.elasticsearch.ElasticsearchTableHandle.Type.QUERY;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class ElasticsearchPageSourceProvider
+        implements ConnectorPageSourceProvider
+{
+    private final ElasticsearchClient client;
+    private final Type jsonType;
+
+    @Inject
+    public ElasticsearchPageSourceProvider(ElasticsearchClient client, TypeManager typeManager)
+    {
+        this.client = requireNonNull(client, "client is null");
+        this.jsonType = typeManager.getType(new TypeSignature(StandardTypes.JSON));
+    }
+
+    @Override
+    public ConnectorPageSource createPageSource(
+            ConnectorTransactionHandle transaction,
+            ConnectorSession session,
+            ConnectorSplit split,
+            ConnectorTableLayoutHandle layout,
+            List<ColumnHandle> columns,
+            SplitContext splitContext,
+            RuntimeStats runtimeStats)
+    {
+        requireNonNull(split, "split is null");
+        requireNonNull(layout, "layout is null");
+        ElasticsearchTableLayoutHandle layoutHandle = (ElasticsearchTableLayoutHandle) layout;
+        ElasticsearchSplit elasticsearchSplit = (ElasticsearchSplit) split;
+
+        if (layoutHandle.getTable().getType().equals(QUERY)) {
+            return new PassthroughQueryPageSource(client, layoutHandle.getTable(), jsonType);
+        }
+
+        if (columns.isEmpty()) {
+            return new CountQueryPageSource(client, session, layoutHandle.getTable(), elasticsearchSplit);
+        }
+        return new ScanQueryPageSource(
+                client,
+                session,
+                layoutHandle.getTable(),
+                elasticsearchSplit,
+                columns.stream()
+                        .map(ElasticsearchColumnHandle.class::cast)
+                        .collect(toImmutableList()));
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchQueryBuilder.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchQueryBuilder.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.Range;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.ConnectorSession;
+import io.airlift.slice.Slice;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.ExistsQueryBuilder;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryStringQueryBuilder;
+import org.elasticsearch.index.query.RangeQueryBuilder;
+import org.elasticsearch.index.query.TermQueryBuilder;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.SmallintType.SMALLINT;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TinyintType.TINYINT;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static java.lang.Math.toIntExact;
+import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
+
+public final class ElasticsearchQueryBuilder
+{
+    private ElasticsearchQueryBuilder() {}
+
+    public static QueryBuilder buildSearchQuery(ConnectorSession session, TupleDomain<ElasticsearchColumnHandle> constraint, Optional<String> query)
+    {
+        BoolQueryBuilder queryBuilder = new BoolQueryBuilder();
+        if (constraint.getDomains().isPresent()) {
+            for (Map.Entry<ElasticsearchColumnHandle, Domain> entry : constraint.getDomains().get().entrySet()) {
+                ElasticsearchColumnHandle column = entry.getKey();
+                Domain domain = entry.getValue();
+
+                checkArgument(!domain.isNone(), "Unexpected NONE domain for %s", column.getName());
+                if (!domain.isAll()) {
+                    queryBuilder.filter(new BoolQueryBuilder().must(buildPredicate(session, column.getName(), domain, column.getType())));
+                }
+            }
+        }
+
+        query.map(QueryStringQueryBuilder::new)
+                .ifPresent(queryBuilder::must);
+
+        if (queryBuilder.hasClauses()) {
+            return queryBuilder;
+        }
+        return new MatchAllQueryBuilder();
+    }
+
+    private static QueryBuilder buildPredicate(ConnectorSession session, String columnName, Domain domain, Type type)
+    {
+        checkArgument(domain.getType().isOrderable(), "Domain type must be orderable");
+        BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
+
+        if (domain.getValues().isNone()) {
+            boolQueryBuilder.mustNot(new ExistsQueryBuilder(columnName));
+            return boolQueryBuilder;
+        }
+
+        if (domain.getValues().isAll()) {
+            boolQueryBuilder.must(new ExistsQueryBuilder(columnName));
+            return boolQueryBuilder;
+        }
+
+        return buildTermQuery(boolQueryBuilder, session, columnName, domain, type);
+    }
+
+    private static QueryBuilder buildTermQuery(BoolQueryBuilder queryBuilder, ConnectorSession session, String columnName, Domain domain, Type type)
+    {
+        for (Range range : domain.getValues().getRanges().getOrderedRanges()) {
+            BoolQueryBuilder rangeQueryBuilder = new BoolQueryBuilder();
+            Set<Object> valuesToInclude = new HashSet<>();
+            checkState(!range.isAll(), "Invalid range for column: " + columnName);
+            if (range.isSingleValue()) {
+                valuesToInclude.add(range.getSingleValue());
+            }
+            else {
+                if (!range.isLowUnbounded()) {
+                    Object lowBound = getValue(session, type, range.getLowBoundedValue());
+                    if (range.isLowInclusive()) {
+                        rangeQueryBuilder.filter(new RangeQueryBuilder(columnName).gte(lowBound));
+                    }
+                    else {
+                        rangeQueryBuilder.filter(new RangeQueryBuilder(columnName).gt(lowBound));
+                    }
+                }
+                if (!range.isHighUnbounded()) {
+                    Object highBound = getValue(session, type, range.getHighBoundedValue());
+                    if (range.isHighInclusive()) {
+                        rangeQueryBuilder.filter(new RangeQueryBuilder(columnName).lte(highBound));
+                    }
+                    else {
+                        rangeQueryBuilder.filter(new RangeQueryBuilder(columnName).lt(highBound));
+                    }
+                }
+            }
+
+            if (valuesToInclude.size() == 1) {
+                rangeQueryBuilder.filter(new TermQueryBuilder(columnName, getValue(session, type, getOnlyElement(valuesToInclude))));
+            }
+            queryBuilder.should(rangeQueryBuilder);
+        }
+        if (domain.isNullAllowed()) {
+            queryBuilder.should(new BoolQueryBuilder().mustNot(new ExistsQueryBuilder(columnName)));
+        }
+        return queryBuilder;
+    }
+
+    private static Object getValue(ConnectorSession session, Type type, Object value)
+    {
+        if (type.equals(BOOLEAN) ||
+                type.equals(TINYINT) ||
+                type.equals(SMALLINT) ||
+                type.equals(INTEGER) ||
+                type.equals(BIGINT) ||
+                type.equals(DOUBLE)) {
+            return value;
+        }
+
+        if (type.equals(REAL)) {
+            return Float.intBitsToFloat(toIntExact(((Long) value)));
+        }
+
+        if (type.equals(VARCHAR)) {
+            return ((Slice) value).toStringUtf8();
+        }
+
+        if (type.equals(TIMESTAMP)) {
+            checkState(session.getSqlFunctionProperties().isLegacyTimestamp(), "New timestamp semantics not yet supported");
+
+            return Instant.ofEpochMilli((Long) value)
+                    .atZone(ZoneId.of(session.getSqlFunctionProperties().getTimeZoneKey().getId()))
+                    .toLocalDateTime()
+                    .format(ISO_DATE_TIME);
+        }
+        throw new IllegalArgumentException("Unhandled type: " + type);
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchSplit.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchSplit.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
+import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.NO_PREFERENCE;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class ElasticsearchSplit
+        implements ConnectorSplit
+{
+    private final String index;
+    private final int shard;
+    private final TupleDomain<ColumnHandle> tupleDomain;
+    private final Optional<String> address;
+
+    @JsonCreator
+    public ElasticsearchSplit(
+            @JsonProperty("index") String index,
+            @JsonProperty("shard") int shard,
+            @JsonProperty("tupleDomain") TupleDomain<ColumnHandle> tupleDomain,
+            @JsonProperty("address") Optional<String> address)
+    {
+        this.index = requireNonNull(index, "index is null");
+        this.shard = shard;
+        this.tupleDomain = requireNonNull(tupleDomain, "tupleDomain is null");
+        this.address = requireNonNull(address, "address is null");
+    }
+
+    @JsonProperty
+    public String getIndex()
+    {
+        return index;
+    }
+
+    @JsonProperty
+    public int getShard()
+    {
+        return shard;
+    }
+
+    @JsonProperty
+    public Optional<String> getAddress()
+    {
+        return address;
+    }
+
+    @JsonProperty
+    public TupleDomain<ColumnHandle> getTupleDomain()
+    {
+        return tupleDomain;
+    }
+
+    @Override
+    public NodeSelectionStrategy getNodeSelectionStrategy()
+    {
+        return NO_PREFERENCE;
+    }
+
+    @Override
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
+    {
+        return address.map(host -> ImmutableList.of(HostAddress.fromString(host)))
+                .orElseGet(ImmutableList::of);
+    }
+
+    @Override
+    public Object getInfo()
+    {
+        return this;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .addValue(index)
+                .addValue(shard)
+                .addValue(tupleDomain)
+                .addValue(address)
+                .toString();
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchSplitManager.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchSplitManager.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.facebook.presto.elasticsearch.client.ElasticsearchClient;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorSplitSource;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.FixedSplitSource;
+import com.facebook.presto.spi.connector.ConnectorSplitManager;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.google.common.collect.ImmutableList;
+
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.elasticsearch.ElasticsearchTableHandle.Type.QUERY;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class ElasticsearchSplitManager
+        implements ConnectorSplitManager
+{
+    private final ElasticsearchClient client;
+
+    @Inject
+    public ElasticsearchSplitManager(ElasticsearchClient client)
+    {
+        this.client = requireNonNull(client, "client is null");
+    }
+
+    @Override
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            ConnectorTableLayoutHandle layout,
+            SplitSchedulingContext splitSchedulingContext)
+    {
+        ElasticsearchTableLayoutHandle layoutHandle = (ElasticsearchTableLayoutHandle) layout;
+        ElasticsearchTableHandle tableHandle = layoutHandle.getTable();
+
+        if (tableHandle.getType().equals(QUERY)) {
+            return new FixedSplitSource(ImmutableList.of(new ElasticsearchSplit(tableHandle.getIndex(), 0, layoutHandle.getTupleDomain(), Optional.empty())));
+        }
+        else {
+            List<ElasticsearchSplit> splits = client.getSearchShards(tableHandle.getIndex()).stream()
+                    .map(shard -> new ElasticsearchSplit(shard.getIndex(), shard.getId(), layoutHandle.getTupleDomain(), shard.getAddress()))
+                    .collect(toImmutableList());
+            return new FixedSplitSource(splits);
+        }
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchTableHandle.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchTableHandle.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public final class ElasticsearchTableHandle
+        implements ConnectorTableHandle
+{
+    public enum Type
+    {
+        SCAN,
+        QUERY
+    }
+
+    private final Type type;
+    private final String schema;
+    private final String index;
+    private final Optional<String> query;
+
+    @JsonCreator
+    public ElasticsearchTableHandle(
+            @JsonProperty("type") Type type,
+            @JsonProperty("schema") String schema,
+            @JsonProperty("index") String index,
+            @JsonProperty("query") Optional<String> query)
+    {
+        this.type = requireNonNull(type, "type is null");
+        this.schema = requireNonNull(schema, "schema is null");
+        this.index = requireNonNull(index, "index is null");
+        this.query = requireNonNull(query, "query is null");
+    }
+
+    @JsonProperty
+    public Type getType()
+    {
+        return type;
+    }
+
+    @JsonProperty
+    public String getIndex()
+    {
+        return index;
+    }
+
+    @JsonProperty
+    public String getSchema()
+    {
+        return schema;
+    }
+
+    @JsonProperty
+    public Optional<String> getQuery()
+    {
+        return query;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(type, schema, index, query);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+
+        ElasticsearchTableHandle other = (ElasticsearchTableHandle) obj;
+        return Objects.equals(this.type, other.getType()) &&
+                Objects.equals(this.getSchema(), other.getSchema()) &&
+                Objects.equals(this.getIndex(), other.getIndex()) &&
+                Objects.equals(this.getQuery(), other.getQuery());
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("type", getType())
+                .add("schema", getSchema())
+                .add("index", getIndex())
+                .add("query", getQuery())
+                .toString();
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchTableLayoutHandle.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchTableLayoutHandle.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public class ElasticsearchTableLayoutHandle
+        implements ConnectorTableLayoutHandle
+{
+    private final ElasticsearchTableHandle table;
+    private final TupleDomain<ColumnHandle> tupleDomain;
+
+    @JsonCreator
+    public ElasticsearchTableLayoutHandle(
+            @JsonProperty("table") ElasticsearchTableHandle table,
+            @JsonProperty("tupleDomain") TupleDomain<ColumnHandle> domain)
+    {
+        this.table = requireNonNull(table, "table is null");
+        this.tupleDomain = requireNonNull(domain, "tupleDomain is null");
+    }
+
+    @JsonProperty
+    public ElasticsearchTableHandle getTable()
+    {
+        return table;
+    }
+
+    @JsonProperty
+    public TupleDomain<ColumnHandle> getTupleDomain()
+    {
+        return tupleDomain;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ElasticsearchTableLayoutHandle that = (ElasticsearchTableLayoutHandle) o;
+        return Objects.equals(table, that.table) &&
+                Objects.equals(tupleDomain, that.tupleDomain);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(table, tupleDomain);
+    }
+
+    @Override
+    public String toString()
+    {
+        return table.toString();
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchTransactionHandle.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchTransactionHandle.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+
+public enum ElasticsearchTransactionHandle
+        implements ConnectorTransactionHandle
+{
+    INSTANCE
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/NodesSystemTable.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/NodesSystemTable.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.elasticsearch.client.ElasticsearchClient;
+import com.facebook.presto.elasticsearch.client.ElasticsearchNode;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorPageSource;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.FixedPageSource;
+import com.facebook.presto.spi.Node;
+import com.facebook.presto.spi.NodeManager;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.SystemTable;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.google.common.collect.ImmutableList;
+
+import javax.inject.Inject;
+
+import java.util.Set;
+
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.common.type.VarcharType.createUnboundedVarcharType;
+import static java.util.Objects.requireNonNull;
+
+public class NodesSystemTable
+        implements SystemTable
+{
+    private static final ConnectorTableMetadata METADATA = new ConnectorTableMetadata(
+            new SchemaTableName("system", "nodes"),
+            ImmutableList.<ColumnMetadata>builder()
+                    .add(new ColumnMetadata("presto_node_id", createUnboundedVarcharType()))
+                    .add(new ColumnMetadata("presto_node_address", createUnboundedVarcharType()))
+                    .add(new ColumnMetadata("elasticsearch_node_id", createUnboundedVarcharType()))
+                    .add(new ColumnMetadata("elasticsearch_node_address", createUnboundedVarcharType()))
+                    .build());
+
+    private final ElasticsearchClient client;
+    private final Node currentNode;
+
+    @Inject
+    public NodesSystemTable(NodeManager nodeManager, ElasticsearchClient client)
+    {
+        requireNonNull(nodeManager, "nodeManager is null");
+
+        this.client = requireNonNull(client, "client is null");
+        currentNode = nodeManager.getCurrentNode();
+    }
+
+    @Override
+    public Distribution getDistribution()
+    {
+        return Distribution.ALL_NODES;
+    }
+
+    @Override
+    public ConnectorTableMetadata getTableMetadata()
+    {
+        return METADATA;
+    }
+
+    @Override
+    public ConnectorPageSource pageSource(ConnectorTransactionHandle transaction, ConnectorSession session, TupleDomain<Integer> constraint)
+    {
+        Set<ElasticsearchNode> nodes = client.getNodes();
+
+        BlockBuilder nodeId = VARCHAR.createBlockBuilder(null, nodes.size());
+        BlockBuilder prestoAddress = VARCHAR.createBlockBuilder(null, nodes.size());
+        BlockBuilder elasticsearchNodeId = VARCHAR.createBlockBuilder(null, nodes.size());
+        BlockBuilder elasticsearchAddress = VARCHAR.createBlockBuilder(null, nodes.size());
+
+        for (ElasticsearchNode node : nodes) {
+            VARCHAR.writeString(nodeId, currentNode.getNodeIdentifier());
+            VARCHAR.writeString(prestoAddress, currentNode.getHostAndPort().toString());
+            VARCHAR.writeString(elasticsearchNodeId, node.getId());
+
+            if (node.getAddress().isPresent()) {
+                VARCHAR.writeString(elasticsearchAddress, node.getAddress().get());
+            }
+            else {
+                elasticsearchAddress.appendNull();
+            }
+        }
+
+        return new FixedPageSource(ImmutableList.of(new Page(
+                nodeId.build(),
+                prestoAddress.build(),
+                elasticsearchNodeId.build(),
+                elasticsearchAddress.build())));
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/PassthroughQueryPageSource.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/PassthroughQueryPageSource.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.PageBuilder;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.elasticsearch.client.ElasticsearchClient;
+import com.facebook.presto.spi.ConnectorPageSource;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slices;
+
+import java.io.IOException;
+
+import static java.util.Objects.requireNonNull;
+
+public class PassthroughQueryPageSource
+        implements ConnectorPageSource
+{
+    private final long readTimeNanos;
+    private final String result;
+    private final Type jsonType;
+    private boolean done;
+
+    public PassthroughQueryPageSource(ElasticsearchClient client, ElasticsearchTableHandle table, Type jsonType)
+    {
+        requireNonNull(client, "client is null");
+        requireNonNull(table, "table is null");
+        this.jsonType = requireNonNull(jsonType, "jsonType is null");
+
+        long start = System.nanoTime();
+        result = client.executeQuery(table.getIndex(), table.getQuery().get());
+        readTimeNanos = System.nanoTime() - start;
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return result.length();
+    }
+
+    @Override
+    public long getCompletedPositions()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return readTimeNanos;
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return done;
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        if (done) {
+            return null;
+        }
+
+        done = true;
+
+        PageBuilder page = new PageBuilder(1, ImmutableList.of(jsonType));
+        page.declarePosition();
+        BlockBuilder column = page.getBlockBuilder(0);
+        jsonType.writeSlice(column, Slices.utf8Slice(result));
+        return page.build();
+    }
+
+    @Override
+    public long getSystemMemoryUsage()
+    {
+        return 0;
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/PasswordConfig.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/PasswordConfig.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigSecuritySensitive;
+
+import javax.validation.constraints.NotNull;
+
+public class PasswordConfig
+{
+    private String user;
+    private String password;
+
+    @NotNull
+    public String getUser()
+    {
+        return user;
+    }
+
+    @Config("elasticsearch.auth.user")
+    public PasswordConfig setUser(String user)
+    {
+        this.user = user;
+        return this;
+    }
+
+    @NotNull
+    public String getPassword()
+    {
+        return password;
+    }
+
+    @Config("elasticsearch.auth.password")
+    @ConfigSecuritySensitive
+    public PasswordConfig setPassword(String password)
+    {
+        this.password = password;
+        return this;
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/ScanQueryPageSource.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/ScanQueryPageSource.java
@@ -1,0 +1,418 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.block.PageBuilderStatus;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.elasticsearch.client.ElasticsearchClient;
+import com.facebook.presto.elasticsearch.decoders.ArrayDecoder;
+import com.facebook.presto.elasticsearch.decoders.BigintDecoder;
+import com.facebook.presto.elasticsearch.decoders.BooleanDecoder;
+import com.facebook.presto.elasticsearch.decoders.Decoder;
+import com.facebook.presto.elasticsearch.decoders.DoubleDecoder;
+import com.facebook.presto.elasticsearch.decoders.IdColumnDecoder;
+import com.facebook.presto.elasticsearch.decoders.IntegerDecoder;
+import com.facebook.presto.elasticsearch.decoders.IpAddressDecoder;
+import com.facebook.presto.elasticsearch.decoders.RealDecoder;
+import com.facebook.presto.elasticsearch.decoders.RowDecoder;
+import com.facebook.presto.elasticsearch.decoders.ScoreColumnDecoder;
+import com.facebook.presto.elasticsearch.decoders.SmallintDecoder;
+import com.facebook.presto.elasticsearch.decoders.SourceColumnDecoder;
+import com.facebook.presto.elasticsearch.decoders.TimestampDecoder;
+import com.facebook.presto.elasticsearch.decoders.TinyintDecoder;
+import com.facebook.presto.elasticsearch.decoders.VarbinaryDecoder;
+import com.facebook.presto.elasticsearch.decoders.VarcharDecoder;
+import com.facebook.presto.spi.ConnectorPageSource;
+import com.facebook.presto.spi.ConnectorSession;
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.ImmutableList;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.SmallintType.SMALLINT;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TinyintType.TINYINT;
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.elasticsearch.BuiltinColumns.ID;
+import static com.facebook.presto.elasticsearch.BuiltinColumns.SCORE;
+import static com.facebook.presto.elasticsearch.BuiltinColumns.SOURCE;
+import static com.facebook.presto.elasticsearch.ElasticsearchQueryBuilder.buildSearchQuery;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+import static java.util.function.Predicate.isEqual;
+import static java.util.stream.Collectors.toList;
+
+public class ScanQueryPageSource
+        implements ConnectorPageSource
+{
+    private static final Logger LOG = Logger.get(ScanQueryPageSource.class);
+
+    private final List<Decoder> decoders;
+
+    private final SearchHitIterator iterator;
+    private final BlockBuilder[] columnBuilders;
+    private final List<ElasticsearchColumnHandle> columns;
+    private long totalBytes;
+    private long readTimeNanos;
+    private long completedPositions;
+
+    public ScanQueryPageSource(
+            ElasticsearchClient client,
+            ConnectorSession session,
+            ElasticsearchTableHandle table,
+            ElasticsearchSplit split,
+            List<ElasticsearchColumnHandle> columns)
+    {
+        requireNonNull(client, "client is null");
+        requireNonNull(columns, "columns is null");
+
+        this.columns = ImmutableList.copyOf(columns);
+
+        decoders = createDecoders(session, columns);
+
+        // When the _source field is requested, we need to bypass column pruning when fetching the document
+        boolean needAllFields = columns.stream()
+                .map(ElasticsearchColumnHandle::getName)
+                .anyMatch(isEqual(SOURCE.getName()));
+
+        // Columns to fetch as doc_fields instead of pulling them out of the JSON source
+        // This is convenient for types such as DATE, TIMESTAMP, etc, which have multiple possible
+        // representations in JSON, but a single normalized representation as doc_field.
+        List<String> documentFields = flattenFields(columns).entrySet().stream()
+                .filter(entry -> entry.getValue().equals(TIMESTAMP))
+                .map(Map.Entry::getKey)
+                .collect(toImmutableList());
+
+        columnBuilders = columns.stream()
+                .map(ElasticsearchColumnHandle::getType)
+                .map(type -> type.createBlockBuilder(null, 1))
+                .toArray(BlockBuilder[]::new);
+
+        List<String> requiredFields = columns.stream()
+                .map(ElasticsearchColumnHandle::getName)
+                .filter(name -> !BuiltinColumns.NAMES.contains(name))
+                .collect(toList());
+
+        // sorting by _doc (index order) get special treatment in Elasticsearch and is more efficient
+        Optional<String> sort = Optional.of("_doc");
+
+        if (table.getQuery().isPresent()) {
+            // However, if we're using a custom Elasticsearch query, use default sorting.
+            // Documents will be scored and returned based on relevance
+            sort = Optional.empty();
+        }
+
+        long start = System.nanoTime();
+        SearchResponse searchResponse = client.beginSearch(
+                split.getIndex(),
+                split.getShard(),
+                buildSearchQuery(session, split.getTupleDomain().transform(ElasticsearchColumnHandle.class::cast), table.getQuery()),
+                needAllFields ? Optional.empty() : Optional.of(requiredFields),
+                documentFields,
+                sort);
+        readTimeNanos += System.nanoTime() - start;
+        this.iterator = new SearchHitIterator(client, () -> searchResponse);
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return totalBytes;
+    }
+
+    @Override
+    public long getCompletedPositions()
+    {
+        return completedPositions;
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return readTimeNanos + iterator.getReadTimeNanos();
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return !iterator.hasNext();
+    }
+
+    @Override
+    public long getSystemMemoryUsage()
+    {
+        return 0;
+    }
+
+    @Override
+    public void close()
+    {
+        iterator.close();
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        long size = 0;
+        while (size < PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES && iterator.hasNext()) {
+            SearchHit hit = iterator.next();
+            Map<String, Object> document = hit.getSourceAsMap();
+
+            for (int i = 0; i < decoders.size(); i++) {
+                String field = columns.get(i).getName();
+                decoders.get(i).decode(hit, () -> getField(document, field), columnBuilders[i]);
+            }
+
+            if (hit.getSourceRef() != null) {
+                totalBytes += hit.getSourceRef().length();
+            }
+
+            completedPositions += 1;
+            size = Arrays.stream(columnBuilders)
+                    .mapToLong(BlockBuilder::getSizeInBytes)
+                    .sum();
+        }
+
+        Block[] blocks = new Block[columnBuilders.length];
+        for (int i = 0; i < columnBuilders.length; i++) {
+            blocks[i] = columnBuilders[i].build();
+            columnBuilders[i] = columnBuilders[i].newBlockBuilderLike(null);
+        }
+
+        return new Page(blocks);
+    }
+
+    public static Object getField(Map<String, Object> document, String field)
+    {
+        Object value = document.get(field);
+        if (value == null) {
+            Map<String, Object> result = new HashMap<>();
+            String prefix = field + ".";
+            for (Map.Entry<String, Object> entry : document.entrySet()) {
+                String key = entry.getKey();
+                if (key.startsWith(prefix)) {
+                    result.put(key.substring(prefix.length()), entry.getValue());
+                }
+            }
+
+            if (!result.isEmpty()) {
+                return result;
+            }
+        }
+
+        return value;
+    }
+
+    private Map<String, Type> flattenFields(List<ElasticsearchColumnHandle> columns)
+    {
+        Map<String, Type> result = new HashMap<>();
+
+        for (ElasticsearchColumnHandle column : columns) {
+            flattenFields(result, column.getName(), column.getType());
+        }
+
+        return result;
+    }
+
+    private void flattenFields(Map<String, Type> result, String fieldName, Type type)
+    {
+        if (type instanceof RowType) {
+            for (RowType.Field field : ((RowType) type).getFields()) {
+                flattenFields(result, appendPath(fieldName, field.getName().get()), field.getType());
+            }
+        }
+        else {
+            result.put(fieldName, type);
+        }
+    }
+
+    private List<Decoder> createDecoders(ConnectorSession session, List<ElasticsearchColumnHandle> columns)
+    {
+        return columns.stream()
+                .map(column -> {
+                    if (column.getName().equals(ID.getName())) {
+                        return new IdColumnDecoder();
+                    }
+
+                    if (column.getName().equals(SCORE.getName())) {
+                        return new ScoreColumnDecoder();
+                    }
+
+                    if (column.getName().equals(SOURCE.getName())) {
+                        return new SourceColumnDecoder();
+                    }
+
+                    return createDecoder(session, column.getName(), column.getType());
+                })
+                .collect(toImmutableList());
+    }
+
+    private Decoder createDecoder(ConnectorSession session, String path, Type type)
+    {
+        if (type.equals(VARCHAR)) {
+            return new VarcharDecoder(path);
+        }
+        else if (type.equals(VARBINARY)) {
+            return new VarbinaryDecoder(path);
+        }
+        else if (type.equals(TIMESTAMP)) {
+            return new TimestampDecoder(session, path);
+        }
+        else if (type.equals(BOOLEAN)) {
+            return new BooleanDecoder(path);
+        }
+        else if (type.equals(DOUBLE)) {
+            return new DoubleDecoder(path);
+        }
+        else if (type.equals(REAL)) {
+            return new RealDecoder(path);
+        }
+        else if (type.equals(TINYINT)) {
+            return new TinyintDecoder(path);
+        }
+        else if (type.equals(SMALLINT)) {
+            return new SmallintDecoder(path);
+        }
+        else if (type.equals(INTEGER)) {
+            return new IntegerDecoder(path);
+        }
+        else if (type.equals(BIGINT)) {
+            return new BigintDecoder(path);
+        }
+        else if (type.getTypeSignature().getBase().equals(StandardTypes.IPADDRESS)) {
+            return new IpAddressDecoder(path, type);
+        }
+        else if (type instanceof RowType) {
+            RowType rowType = (RowType) type;
+
+            List<Decoder> decoders = rowType.getFields().stream()
+                    .map(field -> createDecoder(session, appendPath(path, field.getName().get()), field.getType()))
+                    .collect(toImmutableList());
+
+            List<String> fieldNames = rowType.getFields().stream()
+                    .map(RowType.Field::getName)
+                    .map(Optional::get)
+                    .collect(toImmutableList());
+
+            return new RowDecoder(path, fieldNames, decoders);
+        }
+        else if (type instanceof ArrayType) {
+            Type elementType = ((ArrayType) type).getElementType();
+
+            return new ArrayDecoder(path, createDecoder(session, path, elementType));
+        }
+
+        throw new UnsupportedOperationException("Type not supported: " + type);
+    }
+
+    private static String appendPath(String base, String element)
+    {
+        if (base.isEmpty()) {
+            return element;
+        }
+
+        return base + "." + element;
+    }
+
+    private static class SearchHitIterator
+            extends AbstractIterator<SearchHit>
+    {
+        private final ElasticsearchClient client;
+        private final Supplier<SearchResponse> first;
+
+        private SearchHits searchHits;
+        private String scrollId;
+        private int currentPosition;
+
+        private long readTimeNanos;
+
+        public SearchHitIterator(ElasticsearchClient client, Supplier<SearchResponse> first)
+        {
+            this.client = client;
+            this.first = first;
+        }
+
+        public long getReadTimeNanos()
+        {
+            return readTimeNanos;
+        }
+
+        @Override
+        protected SearchHit computeNext()
+        {
+            if (scrollId == null) {
+                long start = System.nanoTime();
+                SearchResponse response = first.get();
+                readTimeNanos += System.nanoTime() - start;
+                reset(response);
+            }
+            else if (currentPosition == searchHits.getHits().length) {
+                long start = System.nanoTime();
+                SearchResponse response = client.nextPage(scrollId);
+                readTimeNanos += System.nanoTime() - start;
+                reset(response);
+            }
+
+            if (currentPosition == searchHits.getHits().length) {
+                return endOfData();
+            }
+
+            SearchHit hit = searchHits.getAt(currentPosition);
+            currentPosition++;
+
+            return hit;
+        }
+
+        private void reset(SearchResponse response)
+        {
+            scrollId = response.getScrollId();
+            searchHits = response.getHits();
+            currentPosition = 0;
+        }
+
+        public void close()
+        {
+            if (scrollId != null) {
+                try {
+                    client.clearScroll(scrollId);
+                }
+                catch (Exception e) {
+                    // ignore
+                    LOG.debug("Error clearing scroll", e);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/client/AwsRequestSigner.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/client/AwsRequestSigner.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch.client;
+
+import com.amazonaws.DefaultRequest;
+import com.amazonaws.auth.AWS4Signer;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.http.HttpMethodName;
+import org.apache.http.Header;
+import org.apache.http.HttpEntityEnclosingRequest;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.BasicHttpEntity;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.protocol.HttpContext;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.lang.String.CASE_INSENSITIVE_ORDER;
+import static org.apache.http.protocol.HttpCoreContext.HTTP_TARGET_HOST;
+
+class AwsRequestSigner
+        implements HttpRequestInterceptor
+{
+    private static final String SERVICE_NAME = "es";
+    private final AWSCredentialsProvider credentialsProvider;
+    private final AWS4Signer signer;
+
+    public AwsRequestSigner(String region, AWSCredentialsProvider credentialsProvider)
+    {
+        this.credentialsProvider = credentialsProvider;
+        this.signer = new AWS4Signer();
+
+        signer.setServiceName(SERVICE_NAME);
+        signer.setRegionName(region);
+    }
+
+    @Override
+    public void process(final HttpRequest request, final HttpContext context)
+            throws IOException
+    {
+        String method = request.getRequestLine().getMethod();
+
+        URI uri = URI.create(request.getRequestLine().getUri());
+        URIBuilder uriBuilder = new URIBuilder(uri);
+
+        Map<String, List<String>> parameters = new TreeMap<>(CASE_INSENSITIVE_ORDER);
+        for (NameValuePair parameter : uriBuilder.getQueryParams()) {
+            parameters.computeIfAbsent(parameter.getName(), key -> new ArrayList<>())
+                    .add(parameter.getValue());
+        }
+
+        Map<String, String> headers = Arrays.stream(request.getAllHeaders())
+                .collect(toImmutableMap(Header::getName, Header::getValue));
+
+        InputStream content = null;
+        if (request instanceof HttpEntityEnclosingRequest) {
+            HttpEntityEnclosingRequest enclosingRequest = (HttpEntityEnclosingRequest) request;
+            if (enclosingRequest.getEntity() != null) {
+                content = enclosingRequest.getEntity().getContent();
+            }
+        }
+
+        DefaultRequest<?> awsRequest = new DefaultRequest<>(SERVICE_NAME);
+
+        HttpHost host = (HttpHost) context.getAttribute(HTTP_TARGET_HOST);
+        if (host != null) {
+            awsRequest.setEndpoint(URI.create(host.toURI()));
+        }
+        awsRequest.setHttpMethod(HttpMethodName.fromValue(method));
+        awsRequest.setResourcePath(uri.getRawPath());
+        awsRequest.setContent(content);
+        awsRequest.setParameters(parameters);
+        awsRequest.setHeaders(headers);
+
+        signer.sign(awsRequest, credentialsProvider.getCredentials());
+
+        Header[] newHeaders = awsRequest.getHeaders().entrySet().stream()
+                .map(entry -> new BasicHeader(entry.getKey(), entry.getValue()))
+                .toArray(Header[]::new);
+
+        request.setHeaders(newHeaders);
+
+        InputStream newContent = awsRequest.getContent();
+        checkState(newContent == null || request instanceof HttpEntityEnclosingRequest);
+        if (newContent != null) {
+            BasicHttpEntity entity = new BasicHttpEntity();
+            entity.setContent(newContent);
+            ((HttpEntityEnclosingRequest) request).setEntity(entity);
+        }
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/client/CountResponse.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/client/CountResponse.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch.client;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CountResponse
+{
+    private final long count;
+
+    @JsonCreator
+    public CountResponse(@JsonProperty("count") long count)
+    {
+        this.count = count;
+    }
+
+    @JsonProperty
+    public long getCount()
+    {
+        return count;
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/client/ElasticsearchClient.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/client/ElasticsearchClient.java
@@ -1,0 +1,778 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch.client;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.auth.InstanceProfileCredentialsProvider;
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.json.JsonObjectMapperProvider;
+import com.facebook.airlift.log.Logger;
+import com.facebook.airlift.security.pem.PemReader;
+import com.facebook.presto.elasticsearch.AwsSecurityConfig;
+import com.facebook.presto.elasticsearch.ElasticsearchConfig;
+import com.facebook.presto.elasticsearch.PasswordConfig;
+import com.facebook.presto.spi.PrestoException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.units.Duration;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.http.impl.nio.reactor.IOReactorConfig;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.action.search.ClearScrollRequest;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchScrollRequest;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+import javax.security.auth.x500.X500Principal;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateExpiredException;
+import java.security.cert.CertificateNotYetValidException;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static com.facebook.presto.elasticsearch.ElasticsearchErrorCode.ELASTICSEARCH_CONNECTION_ERROR;
+import static com.facebook.presto.elasticsearch.ElasticsearchErrorCode.ELASTICSEARCH_INVALID_RESPONSE;
+import static com.facebook.presto.elasticsearch.ElasticsearchErrorCode.ELASTICSEARCH_QUERY_FAILURE;
+import static com.facebook.presto.elasticsearch.ElasticsearchErrorCode.ELASTICSEARCH_SSL_INITIALIZATION_FAILURE;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.lang.StrictMath.toIntExact;
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.list;
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
+import static org.elasticsearch.action.search.SearchType.QUERY_THEN_FETCH;
+
+public class ElasticsearchClient
+{
+    private static final Logger LOG = Logger.get(ElasticsearchClient.class);
+    private static final JsonCodec<SearchShardsResponse> SEARCH_SHARDS_RESPONSE_CODEC = jsonCodec(SearchShardsResponse.class);
+    private static final JsonCodec<NodesResponse> NODES_RESPONSE_CODEC = jsonCodec(NodesResponse.class);
+    private static final JsonCodec<CountResponse> COUNT_RESPONSE_CODEC = jsonCodec(CountResponse.class);
+    private static final ObjectMapper OBJECT_MAPPER = new JsonObjectMapperProvider().get();
+    private static final Pattern ADDRESS_PATTERN = Pattern.compile("((?<cname>[^/]+)/)?(?<ip>.+):(?<port>\\d+)");
+
+    private final RestHighLevelClient client;
+    private final int scrollSize;
+    private final Duration scrollTimeout;
+
+    private final AtomicReference<Set<ElasticsearchNode>> nodes = new AtomicReference<>(ImmutableSet.of());
+    private final ScheduledExecutorService executor = newSingleThreadScheduledExecutor(daemonThreadsNamed("NodeRefresher"));
+    private final AtomicBoolean started = new AtomicBoolean();
+    private final Duration refreshInterval;
+    private final boolean tlsEnabled;
+    private final boolean ignorePublishAddress;
+
+    @Inject
+    public ElasticsearchClient(
+            ElasticsearchConfig config,
+            Optional<AwsSecurityConfig> awsSecurityConfig,
+            Optional<PasswordConfig> passwordConfig)
+    {
+        client = createClient(config, awsSecurityConfig, passwordConfig);
+
+        this.ignorePublishAddress = config.isIgnorePublishAddress();
+        this.scrollSize = config.getScrollSize();
+        this.scrollTimeout = config.getScrollTimeout();
+        this.refreshInterval = config.getNodeRefreshInterval();
+        this.tlsEnabled = config.isTlsEnabled();
+    }
+
+    @PostConstruct
+    public void initialize()
+    {
+        if (!started.getAndSet(true)) {
+            // do the first refresh eagerly
+            refreshNodes();
+            executor.scheduleWithFixedDelay(this::refreshNodes, refreshInterval.toMillis(), refreshInterval.toMillis(), TimeUnit.MILLISECONDS);
+        }
+    }
+
+    @PreDestroy
+    public void close()
+            throws IOException
+    {
+        executor.shutdownNow();
+        client.close();
+    }
+
+    private void refreshNodes()
+    {
+        // discover other nodes in the cluster and add them to the client
+        try {
+            Set<ElasticsearchNode> nodes = fetchNodes();
+
+            HttpHost[] hosts = nodes.stream()
+                    .map(ElasticsearchNode::getAddress)
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .map(address -> HttpHost.create(format("%s://%s", tlsEnabled ? "https" : "http", address)))
+                    .toArray(HttpHost[]::new);
+
+            if (hosts.length > 0 && !ignorePublishAddress) {
+                client.getLowLevelClient().setHosts(hosts);
+            }
+            this.nodes.set(nodes);
+        }
+        catch (Throwable e) {
+            // Catch all exceptions here since throwing an exception from executor#scheduleWithFixedDelay method
+            // suppresses all future scheduled invocations
+            LOG.error(e, "Error refreshing nodes");
+        }
+    }
+
+    private static RestHighLevelClient createClient(
+            ElasticsearchConfig config,
+            Optional<AwsSecurityConfig> awsSecurityConfig,
+            Optional<PasswordConfig> passwordConfig)
+    {
+        RestClientBuilder builder = RestClient.builder(
+                new HttpHost(config.getHost(), config.getPort(), config.isTlsEnabled() ? "https" : "http"))
+                .setMaxRetryTimeoutMillis((int) config.getMaxRetryTime().toMillis());
+
+        builder.setHttpClientConfigCallback(ignored -> {
+            RequestConfig requestConfig = RequestConfig.custom()
+                    .setConnectTimeout(toIntExact(config.getConnectTimeout().toMillis()))
+                    .setSocketTimeout(toIntExact(config.getRequestTimeout().toMillis()))
+                    .build();
+
+            IOReactorConfig reactorConfig = IOReactorConfig.custom()
+                    .setIoThreadCount(config.getHttpThreadCount())
+                    .build();
+
+            // the client builder passed to the call-back is configured to use system properties, which makes it
+            // impossible to configure concurrency settings, so we need to build a new one from scratch
+            HttpAsyncClientBuilder clientBuilder = HttpAsyncClientBuilder.create()
+                    .setDefaultRequestConfig(requestConfig)
+                    .setDefaultIOReactorConfig(reactorConfig)
+                    .setMaxConnPerRoute(config.getMaxHttpConnections())
+                    .setMaxConnTotal(config.getMaxHttpConnections());
+
+            if (config.isTlsEnabled()) {
+                buildSslContext(config.getKeystorePath(), config.getKeystorePassword(), config.getTrustStorePath(), config.getTruststorePassword())
+                        .ifPresent(clientBuilder::setSSLContext);
+
+                if (config.isVerifyHostnames()) {
+                    clientBuilder.setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE);
+                }
+            }
+
+            passwordConfig.ifPresent(securityConfig -> {
+                CredentialsProvider credentials = new BasicCredentialsProvider();
+                credentials.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(securityConfig.getUser(), securityConfig.getPassword()));
+                clientBuilder.setDefaultCredentialsProvider(credentials);
+            });
+
+            awsSecurityConfig.ifPresent(securityConfig -> clientBuilder.addInterceptorLast(new AwsRequestSigner(
+                    securityConfig.getRegion(),
+                    getAwsCredentialsProvider(securityConfig))));
+
+            return clientBuilder;
+        });
+
+        return new RestHighLevelClient(builder);
+    }
+
+    private static AWSCredentialsProvider getAwsCredentialsProvider(AwsSecurityConfig config)
+    {
+        if (config.getAccessKey().isPresent() && config.getSecretKey().isPresent()) {
+            return new AWSStaticCredentialsProvider(new BasicAWSCredentials(
+                    config.getAccessKey().get(),
+                    config.getSecretKey().get()));
+        }
+        if (config.isUseInstanceCredentials()) {
+            return InstanceProfileCredentialsProvider.getInstance();
+        }
+        return DefaultAWSCredentialsProviderChain.getInstance();
+    }
+
+    private static Optional<SSLContext> buildSslContext(
+            Optional<File> keyStorePath,
+            Optional<String> keyStorePassword,
+            Optional<File> trustStorePath,
+            Optional<String> trustStorePassword)
+    {
+        if (!keyStorePath.isPresent() && !trustStorePath.isPresent()) {
+            return Optional.empty();
+        }
+
+        try {
+            // load KeyStore if configured and get KeyManagers
+            KeyStore keyStore = null;
+            KeyManager[] keyManagers = null;
+            if (keyStorePath.isPresent()) {
+                char[] keyManagerPassword;
+                try {
+                    // attempt to read the key store as a PEM file
+                    keyStore = PemReader.loadKeyStore(keyStorePath.get(), keyStorePath.get(), keyStorePassword);
+                    // for PEM encoded keys, the password is used to decrypt the specific key (and does not protect the keystore itself)
+                    keyManagerPassword = new char[0];
+                }
+                catch (IOException | GeneralSecurityException ignored) {
+                    keyManagerPassword = keyStorePassword.map(String::toCharArray).orElse(null);
+
+                    keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+                    try (InputStream in = new FileInputStream(keyStorePath.get())) {
+                        keyStore.load(in, keyManagerPassword);
+                    }
+                }
+
+                validateCertificates(keyStore);
+                KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+                keyManagerFactory.init(keyStore, keyManagerPassword);
+                keyManagers = keyManagerFactory.getKeyManagers();
+            }
+
+            // load TrustStore if configured, otherwise use KeyStore
+            KeyStore trustStore = keyStore;
+            if (trustStorePath.isPresent()) {
+                trustStore = loadTrustStore(trustStorePath.get(), trustStorePassword);
+            }
+
+            // create TrustManagerFactory
+            TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            trustManagerFactory.init(trustStore);
+
+            // get X509TrustManager
+            TrustManager[] trustManagers = trustManagerFactory.getTrustManagers();
+            if ((trustManagers.length != 1) || !(trustManagers[0] instanceof X509TrustManager)) {
+                throw new RuntimeException("Unexpected default trust managers:" + Arrays.toString(trustManagers));
+            }
+            X509TrustManager trustManager = (X509TrustManager) trustManagers[0];
+
+            // create SSLContext
+            SSLContext result = SSLContext.getInstance("SSL");
+            result.init(keyManagers, new TrustManager[] {trustManager}, null);
+            return Optional.of(result);
+        }
+        catch (GeneralSecurityException | IOException e) {
+            throw new PrestoException(ELASTICSEARCH_SSL_INITIALIZATION_FAILURE, e);
+        }
+    }
+
+    private static KeyStore loadTrustStore(File trustStorePath, Optional<String> trustStorePassword)
+            throws IOException, GeneralSecurityException
+    {
+        KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        try {
+            // attempt to read the trust store as a PEM file
+            List<X509Certificate> certificateChain = PemReader.readCertificateChain(trustStorePath);
+            if (!certificateChain.isEmpty()) {
+                trustStore.load(null, null);
+                for (X509Certificate certificate : certificateChain) {
+                    X500Principal principal = certificate.getSubjectX500Principal();
+                    trustStore.setCertificateEntry(principal.getName(), certificate);
+                }
+                return trustStore;
+            }
+        }
+        catch (IOException | GeneralSecurityException ignored) {
+        }
+
+        try (InputStream in = new FileInputStream(trustStorePath)) {
+            trustStore.load(in, trustStorePassword.map(String::toCharArray).orElse(null));
+        }
+        return trustStore;
+    }
+
+    private static void validateCertificates(KeyStore keyStore)
+            throws GeneralSecurityException
+    {
+        for (String alias : list(keyStore.aliases())) {
+            if (!keyStore.isKeyEntry(alias)) {
+                continue;
+            }
+            Certificate certificate = keyStore.getCertificate(alias);
+            if (!(certificate instanceof X509Certificate)) {
+                continue;
+            }
+            try {
+                ((X509Certificate) certificate).checkValidity();
+            }
+            catch (CertificateExpiredException e) {
+                throw new CertificateExpiredException("KeyStore certificate is expired: " + e.getMessage());
+            }
+            catch (CertificateNotYetValidException e) {
+                throw new CertificateNotYetValidException("KeyStore certificate is not yet valid: " + e.getMessage());
+            }
+        }
+    }
+
+    private Set<ElasticsearchNode> fetchNodes()
+    {
+        NodesResponse nodesResponse = doRequest("/_nodes/http", NODES_RESPONSE_CODEC::fromJson);
+
+        ImmutableSet.Builder<ElasticsearchNode> result = ImmutableSet.builder();
+        for (Map.Entry<String, NodesResponse.Node> entry : nodesResponse.getNodes().entrySet()) {
+            String nodeId = entry.getKey();
+            NodesResponse.Node node = entry.getValue();
+
+            if (node.getRoles().contains("data")) {
+                Optional<String> address = node.getAddress()
+                        .flatMap(ElasticsearchClient::extractAddress);
+
+                result.add(new ElasticsearchNode(nodeId, address));
+            }
+        }
+        return result.build();
+    }
+
+    public Set<ElasticsearchNode> getNodes()
+    {
+        return nodes.get();
+    }
+
+    public List<Shard> getSearchShards(String index)
+    {
+        Map<String, ElasticsearchNode> nodeById = getNodes().stream()
+                .collect(toImmutableMap(ElasticsearchNode::getId, Function.identity()));
+
+        SearchShardsResponse shardsResponse = doRequest(format("/%s/_search_shards", index), SEARCH_SHARDS_RESPONSE_CODEC::fromJson);
+
+        ImmutableList.Builder<Shard> shards = ImmutableList.builder();
+        List<ElasticsearchNode> nodes = ImmutableList.copyOf(nodeById.values());
+
+        for (List<SearchShardsResponse.Shard> shardGroup : shardsResponse.getShardGroups()) {
+            Stream<SearchShardsResponse.Shard> preferred = shardGroup.stream()
+                    .sorted(this::shardPreference);
+
+            Optional<SearchShardsResponse.Shard> candidate = preferred
+                    .filter(shard -> shard.getNode() != null && nodeById.containsKey(shard.getNode()))
+                    .findFirst();
+
+            SearchShardsResponse.Shard chosen;
+            ElasticsearchNode node;
+            if (candidate.isPresent()) {
+                chosen = candidate.get();
+                node = nodeById.get(chosen.getNode());
+            }
+            else {
+                // pick an arbitrary shard with and assign to an arbitrary node
+                chosen = preferred.findFirst().get();
+                node = nodes.get(chosen.getShard() % nodes.size());
+            }
+            shards.add(new Shard(chosen.getIndex(), chosen.getShard(), node.getAddress()));
+        }
+
+        return shards.build();
+    }
+
+    private int shardPreference(SearchShardsResponse.Shard left, SearchShardsResponse.Shard right)
+    {
+        // Favor non-primary shards
+        if (left.isPrimary() == right.isPrimary()) {
+            return 0;
+        }
+
+        return left.isPrimary() ? 1 : -1;
+    }
+
+    public List<String> getIndexes()
+    {
+        return doRequest("/_cat/indices?h=index&format=json&s=index:asc", body -> {
+            try {
+                ImmutableList.Builder<String> result = ImmutableList.builder();
+                JsonNode root = OBJECT_MAPPER.readTree(body);
+                for (int i = 0; i < root.size(); i++) {
+                    result.add(root.get(i).get("index").asText());
+                }
+                return result.build();
+            }
+            catch (IOException e) {
+                throw new PrestoException(ELASTICSEARCH_INVALID_RESPONSE, e);
+            }
+        });
+    }
+
+    public Map<String, List<String>> getAliases()
+    {
+        return doRequest("/_aliases", body -> {
+            try {
+                ImmutableMap.Builder<String, List<String>> result = ImmutableMap.builder();
+                JsonNode root = OBJECT_MAPPER.readTree(body);
+
+                Iterator<Map.Entry<String, JsonNode>> elements = root.fields();
+                while (elements.hasNext()) {
+                    Map.Entry<String, JsonNode> element = elements.next();
+                    JsonNode aliases = element.getValue().get("aliases");
+                    Iterator<String> aliasNames = aliases.fieldNames();
+                    if (aliasNames.hasNext()) {
+                        result.put(element.getKey(), ImmutableList.copyOf(aliasNames));
+                    }
+                }
+                return result.build();
+            }
+            catch (IOException e) {
+                throw new PrestoException(ELASTICSEARCH_INVALID_RESPONSE, e);
+            }
+        });
+    }
+
+    public IndexMetadata getIndexMetadata(String index)
+    {
+        String path = format("/%s/_mappings", index);
+
+        return doRequest(path, body -> {
+            try {
+                JsonNode mappings = OBJECT_MAPPER.readTree(body)
+                        .elements().next()
+                        .get("mappings");
+
+                if (!mappings.has("properties")) {
+                    // Older versions of ElasticSearch supported multiple "type" mappings
+                    // for a given index. Newer versions support only one and don't
+                    // expose it in the document. Here we skip it if it's present.
+                    mappings = mappings.elements().next();
+                }
+
+                JsonNode metaNode = nullSafeNode(mappings, "_meta");
+
+                return new IndexMetadata(parseType(mappings.get("properties"), nullSafeNode(metaNode, "presto")));
+            }
+            catch (IOException e) {
+                throw new PrestoException(ELASTICSEARCH_INVALID_RESPONSE, e);
+            }
+        });
+    }
+
+    private IndexMetadata.ObjectType parseType(JsonNode properties, JsonNode metaProperties)
+    {
+        Iterator<Map.Entry<String, JsonNode>> entries = properties.fields();
+
+        ImmutableList.Builder<IndexMetadata.Field> result = ImmutableList.builder();
+        while (entries.hasNext()) {
+            Map.Entry<String, JsonNode> field = entries.next();
+
+            String name = field.getKey();
+            JsonNode value = field.getValue();
+
+            String type = "object";
+            if (value.has("type")) {
+                type = value.get("type").asText();
+            }
+
+            JsonNode metaNode = nullSafeNode(metaProperties, name);
+            boolean isArray = !metaNode.isNull() && metaNode.has("isArray") && metaNode.get("isArray").asBoolean();
+
+            switch (type) {
+                case "date":
+                    List<String> formats = ImmutableList.of();
+                    if (value.has("format")) {
+                        formats = Arrays.asList(value.get("format").asText().split("\\|\\|"));
+                    }
+                    result.add(new IndexMetadata.Field(isArray, name, new IndexMetadata.DateTimeType(formats)));
+                    break;
+
+                case "nested":
+                case "object":
+                    if (value.has("properties")) {
+                        result.add(new IndexMetadata.Field(isArray, name, parseType(value.get("properties"), metaNode)));
+                    }
+                    else {
+                        LOG.debug("Ignoring empty object field: %s", name);
+                    }
+                    break;
+
+                default:
+                    result.add(new IndexMetadata.Field(isArray, name, new IndexMetadata.PrimitiveType(type)));
+            }
+        }
+
+        return new IndexMetadata.ObjectType(result.build());
+    }
+
+    private JsonNode nullSafeNode(JsonNode jsonNode, String name)
+    {
+        if (jsonNode == null || jsonNode.isNull() || jsonNode.get(name) == null) {
+            return NullNode.getInstance();
+        }
+        return jsonNode.get(name);
+    }
+
+    public String executeQuery(String index, String query)
+    {
+        String path = format("/%s/_search", index);
+
+        Response response;
+        try {
+            response = client.getLowLevelClient()
+                    .performRequest(
+                            "GET",
+                            path,
+                            ImmutableMap.of(),
+                            new ByteArrayEntity(query.getBytes(UTF_8)),
+                            new BasicHeader("Content-Type", "application/json"),
+                            new BasicHeader("Accept-Encoding", "application/json"));
+        }
+        catch (IOException e) {
+            throw new PrestoException(ELASTICSEARCH_CONNECTION_ERROR, e);
+        }
+
+        String body;
+        try {
+            body = EntityUtils.toString(response.getEntity());
+        }
+        catch (IOException e) {
+            throw new PrestoException(ELASTICSEARCH_INVALID_RESPONSE, e);
+        }
+
+        return body;
+    }
+
+    public SearchResponse beginSearch(String index, int shard, QueryBuilder query, Optional<List<String>> fields, List<String> documentFields, Optional<String> sort)
+    {
+        SearchSourceBuilder sourceBuilder = SearchSourceBuilder.searchSource()
+                .query(query)
+                .size(scrollSize);
+
+        sort.ifPresent(sourceBuilder::sort);
+
+        fields.ifPresent(values -> {
+            if (values.isEmpty()) {
+                sourceBuilder.fetchSource(false);
+            }
+            else {
+                sourceBuilder.fetchSource(values.toArray(new String[0]), null);
+            }
+        });
+        documentFields.forEach(sourceBuilder::docValueField);
+
+        SearchRequest request = new SearchRequest(index)
+                .searchType(QUERY_THEN_FETCH)
+                .preference("_shards:" + shard)
+                .scroll(new TimeValue(scrollTimeout.toMillis()))
+                .source(sourceBuilder);
+
+        try {
+            return client.search(request);
+        }
+        catch (IOException e) {
+            throw new PrestoException(ELASTICSEARCH_CONNECTION_ERROR, e);
+        }
+        catch (ElasticsearchStatusException e) {
+            Throwable[] suppressed = e.getSuppressed();
+            if (suppressed.length > 0) {
+                Throwable cause = suppressed[0];
+                if (cause instanceof ResponseException) {
+                    HttpEntity entity = ((ResponseException) cause).getResponse().getEntity();
+                    try {
+                        JsonNode reason = OBJECT_MAPPER.readTree(entity.getContent()).path("error")
+                                .path("root_cause")
+                                .path(0)
+                                .path("reason");
+
+                        if (!reason.isMissingNode()) {
+                            throw new PrestoException(ELASTICSEARCH_QUERY_FAILURE, reason.asText(), e);
+                        }
+                    }
+                    catch (IOException ex) {
+                        e.addSuppressed(ex);
+                    }
+                }
+            }
+
+            throw new PrestoException(ELASTICSEARCH_CONNECTION_ERROR, e);
+        }
+    }
+
+    public SearchResponse nextPage(String scrollId)
+    {
+        SearchScrollRequest request = new SearchScrollRequest(scrollId)
+                .scroll(new TimeValue(scrollTimeout.toMillis()));
+
+        try {
+            return client.searchScroll(request);
+        }
+        catch (IOException e) {
+            throw new PrestoException(ELASTICSEARCH_CONNECTION_ERROR, e);
+        }
+    }
+
+    public long count(String index, int shard, QueryBuilder query)
+    {
+        SearchSourceBuilder sourceBuilder = SearchSourceBuilder.searchSource()
+                .query(query);
+
+        LOG.debug("Count: %s:%s, query: %s", index, shard, sourceBuilder);
+
+        Response response;
+        try {
+            response = client.getLowLevelClient()
+                    .performRequest(
+                            "GET",
+                            format("/%s/_count?preference=_shards:%s", index, shard),
+                            ImmutableMap.of(),
+                            new StringEntity(sourceBuilder.toString()),
+                            new BasicHeader("Content-Type", "application/json"));
+        }
+        catch (ResponseException e) {
+            throw propagate(e);
+        }
+        catch (IOException e) {
+            throw new PrestoException(ELASTICSEARCH_CONNECTION_ERROR, e);
+        }
+
+        try {
+            return COUNT_RESPONSE_CODEC.fromJson(EntityUtils.toByteArray(response.getEntity()))
+                    .getCount();
+        }
+        catch (IOException e) {
+            throw new PrestoException(ELASTICSEARCH_INVALID_RESPONSE, e);
+        }
+    }
+
+    public void clearScroll(String scrollId)
+    {
+        ClearScrollRequest request = new ClearScrollRequest();
+        request.addScrollId(scrollId);
+        try {
+            client.clearScroll(request);
+        }
+        catch (IOException e) {
+            throw new PrestoException(ELASTICSEARCH_CONNECTION_ERROR, e);
+        }
+    }
+
+    private <T> T doRequest(String path, ResponseHandler<T> handler)
+    {
+        checkArgument(path.startsWith("/"), "path must be an absolute path");
+
+        Response response;
+        try {
+            response = client.getLowLevelClient()
+                    .performRequest("GET", path);
+        }
+        catch (IOException e) {
+            throw new PrestoException(ELASTICSEARCH_CONNECTION_ERROR, e);
+        }
+
+        String body;
+        try {
+            body = EntityUtils.toString(response.getEntity());
+        }
+        catch (IOException e) {
+            throw new PrestoException(ELASTICSEARCH_INVALID_RESPONSE, e);
+        }
+        return handler.process(body);
+    }
+
+    private static PrestoException propagate(ResponseException exception)
+    {
+        HttpEntity entity = exception.getResponse().getEntity();
+
+        if (entity != null && entity.getContentType() != null) {
+            try {
+                JsonNode reason = OBJECT_MAPPER.readTree(entity.getContent()).path("error")
+                        .path("root_cause")
+                        .path(0)
+                        .path("reason");
+
+                if (!reason.isMissingNode()) {
+                    throw new PrestoException(ELASTICSEARCH_QUERY_FAILURE, reason.asText(), exception);
+                }
+            }
+            catch (IOException e) {
+                PrestoException result = new PrestoException(ELASTICSEARCH_QUERY_FAILURE, exception);
+                result.addSuppressed(e);
+                throw result;
+            }
+        }
+
+        throw new PrestoException(ELASTICSEARCH_QUERY_FAILURE, exception);
+    }
+
+    @VisibleForTesting
+    static Optional<String> extractAddress(String address)
+    {
+        Matcher matcher = ADDRESS_PATTERN.matcher(address);
+
+        if (!matcher.matches()) {
+            return Optional.empty();
+        }
+
+        String cname = matcher.group("cname");
+        String ip = matcher.group("ip");
+        String port = matcher.group("port");
+
+        if (cname != null) {
+            return Optional.of(cname + ":" + port);
+        }
+
+        return Optional.of(ip + ":" + port);
+    }
+
+    private interface ResponseHandler<T>
+    {
+        T process(String body);
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/client/ElasticsearchNode.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/client/ElasticsearchNode.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch.client;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class ElasticsearchNode
+{
+    private final String id;
+    private final Optional<String> address;
+
+    public ElasticsearchNode(String id, Optional<String> address)
+    {
+        this.id = requireNonNull(id, "id is null");
+        this.address = requireNonNull(address, "address is null");
+    }
+
+    public String getId()
+    {
+        return id;
+    }
+
+    public Optional<String> getAddress()
+    {
+        return address;
+    }
+
+    @Override
+    public String toString()
+    {
+        return id + "@" + address.orElse("<unknown>");
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/client/IndexMetadata.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/client/IndexMetadata.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch.client;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class IndexMetadata
+{
+    private final ObjectType schema;
+
+    public IndexMetadata(ObjectType schema)
+    {
+        this.schema = requireNonNull(schema, "schema is null");
+    }
+
+    public ObjectType getSchema()
+    {
+        return schema;
+    }
+
+    public static class Field
+    {
+        private final boolean isArray;
+        private final String name;
+        private final Type type;
+
+        public Field(boolean isArray, String name, Type type)
+        {
+            this.isArray = isArray;
+            this.name = requireNonNull(name, "name is null");
+            this.type = requireNonNull(type, "type is null");
+        }
+
+        public boolean isArray()
+        {
+            return isArray;
+        }
+
+        public String getName()
+        {
+            return name;
+        }
+
+        public Type getType()
+        {
+            return type;
+        }
+    }
+
+    public interface Type {}
+
+    public static class PrimitiveType
+            implements Type
+    {
+        private final String name;
+
+        public PrimitiveType(String name)
+        {
+            this.name = requireNonNull(name, "name is null");
+        }
+
+        public String getName()
+        {
+            return name;
+        }
+    }
+
+    public static class DateTimeType
+            implements Type
+    {
+        private final List<String> formats;
+
+        public DateTimeType(List<String> formats)
+        {
+            requireNonNull(formats, "formats is null");
+
+            this.formats = ImmutableList.copyOf(formats);
+        }
+
+        public List<String> getFormats()
+        {
+            return formats;
+        }
+    }
+
+    public static class ObjectType
+            implements Type
+    {
+        private final List<Field> fields;
+
+        public ObjectType(List<Field> fields)
+        {
+            requireNonNull(fields, "fields is null");
+
+            this.fields = ImmutableList.copyOf(fields);
+        }
+
+        public List<Field> getFields()
+        {
+            return fields;
+        }
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/client/NodesResponse.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/client/NodesResponse.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch.client;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+public class NodesResponse
+{
+    private final Map<String, Node> nodes;
+
+    @JsonCreator
+    public NodesResponse(@JsonProperty("nodes") Map<String, Node> nodes)
+    {
+        requireNonNull(nodes, "nodes is null");
+
+        this.nodes = ImmutableMap.copyOf(nodes);
+    }
+
+    public Map<String, Node> getNodes()
+    {
+        return nodes;
+    }
+
+    public static class Node
+    {
+        private final Set<String> roles;
+        private final Optional<Http> http;
+
+        @JsonCreator
+        public Node(
+                @JsonProperty("roles") Set<String> roles,
+                @JsonProperty("http") Optional<Http> http)
+        {
+            this.roles = ImmutableSet.copyOf(roles);
+            this.http = requireNonNull(http, "http is null");
+        }
+
+        public Set<String> getRoles()
+        {
+            return roles;
+        }
+
+        public Optional<String> getAddress()
+        {
+            return http.map(Http::getAddress);
+        }
+    }
+
+    public static class Http
+    {
+        private final String address;
+
+        @JsonCreator
+        public Http(@JsonProperty("publish_address") String address)
+        {
+            this.address = address;
+        }
+
+        public String getAddress()
+        {
+            return address;
+        }
+
+        @Override
+        public String toString()
+        {
+            return address;
+        }
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/client/SearchShardsResponse.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/client/SearchShardsResponse.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch.client;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class SearchShardsResponse
+{
+    private final List<List<Shard>> shardGroups;
+
+    @JsonCreator
+    public SearchShardsResponse(@JsonProperty("shards") List<List<Shard>> shardGroups)
+    {
+        requireNonNull(shardGroups, "shardGroups is null");
+
+        this.shardGroups = ImmutableList.copyOf(shardGroups);
+    }
+
+    public List<List<Shard>> getShardGroups()
+    {
+        return shardGroups;
+    }
+
+    public static class Shard
+    {
+        private final String index;
+        private final boolean primary;
+        private final String node;
+        private final int shard;
+
+        @JsonCreator
+        public Shard(
+                @JsonProperty("index") String index,
+                @JsonProperty("shard") int shard,
+                @JsonProperty("primary") boolean primary,
+                @JsonProperty("node") String node)
+        {
+            this.index = requireNonNull(index, "index is null");
+            this.shard = shard;
+            this.primary = primary;
+            this.node = requireNonNull(node, "node is null");
+        }
+
+        public String getIndex()
+        {
+            return index;
+        }
+
+        public boolean isPrimary()
+        {
+            return primary;
+        }
+
+        public String getNode()
+        {
+            return node;
+        }
+
+        public int getShard()
+        {
+            return shard;
+        }
+
+        @Override
+        public String toString()
+        {
+            return index + ":" + shard + "@" + node + (primary ? "[primary]" : "[replica]");
+        }
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/client/Shard.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/client/Shard.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch.client;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class Shard
+{
+    private final String index;
+    private final int id;
+    private final Optional<String> address;
+
+    public Shard(String index, int id, Optional<String> address)
+    {
+        this.index = requireNonNull(index, "index is null");
+        this.id = id;
+        this.address = requireNonNull(address, "address is null");
+    }
+
+    public String getIndex()
+    {
+        return index;
+    }
+
+    public int getId()
+    {
+        return id;
+    }
+
+    public Optional<String> getAddress()
+    {
+        return address;
+    }
+
+    @Override
+    public String toString()
+    {
+        return index + ":" + id + "@" + address.orElse("<unknown>");
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/decoders/ArrayDecoder.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/decoders/ArrayDecoder.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch.decoders;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.spi.PrestoException;
+import org.elasticsearch.search.SearchHit;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import static com.facebook.presto.elasticsearch.ElasticsearchErrorCode.ELASTICSEARCH_TYPE_MISMATCH;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class ArrayDecoder
+        implements Decoder
+{
+    private final String path;
+    private final Decoder elementDecoder;
+
+    public ArrayDecoder(String path, Decoder elementDecoder)
+    {
+        this.path = requireNonNull(path, "path is null");
+        this.elementDecoder = elementDecoder;
+    }
+
+    @Override
+    public void decode(SearchHit hit, Supplier<Object> getter, BlockBuilder output)
+    {
+        Object data = getter.get();
+
+        if (data == null) {
+            output.appendNull();
+        }
+        else if (data instanceof List) {
+            BlockBuilder array = output.beginBlockEntry();
+            ((List) data).forEach(element -> elementDecoder.decode(hit, () -> element, array));
+            output.closeEntry();
+        }
+        else {
+            throw new PrestoException(ELASTICSEARCH_TYPE_MISMATCH, format("Expected list of elements for field '%s' of type ARRAY: %s [%s]", path, data, data.getClass().getSimpleName()));
+        }
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/decoders/BigintDecoder.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/decoders/BigintDecoder.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch.decoders;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.spi.PrestoException;
+import org.elasticsearch.search.SearchHit;
+
+import java.util.function.Supplier;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.elasticsearch.ElasticsearchErrorCode.ELASTICSEARCH_TYPE_MISMATCH;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class BigintDecoder
+        implements Decoder
+{
+    private final String path;
+
+    public BigintDecoder(String path)
+    {
+        this.path = requireNonNull(path, "path is null");
+    }
+
+    @Override
+    public void decode(SearchHit hit, Supplier<Object> getter, BlockBuilder output)
+    {
+        Object value = getter.get();
+        if (value == null) {
+            output.appendNull();
+        }
+        else if (value instanceof Number) {
+            BIGINT.writeLong(output, ((Number) value).longValue());
+        }
+        else {
+            throw new PrestoException(ELASTICSEARCH_TYPE_MISMATCH, format("Expected a numeric value for field %s of type BIGINT: %s [%s]", path, value, value.getClass().getSimpleName()));
+        }
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/decoders/BooleanDecoder.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/decoders/BooleanDecoder.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch.decoders;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.spi.PrestoException;
+import org.elasticsearch.search.SearchHit;
+
+import java.util.function.Supplier;
+
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.elasticsearch.ElasticsearchErrorCode.ELASTICSEARCH_TYPE_MISMATCH;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class BooleanDecoder
+        implements Decoder
+{
+    private final String path;
+
+    public BooleanDecoder(String path)
+    {
+        this.path = requireNonNull(path, "path is null");
+    }
+
+    @Override
+    public void decode(SearchHit hit, Supplier<Object> getter, BlockBuilder output)
+    {
+        Object value = getter.get();
+        if (value == null) {
+            output.appendNull();
+        }
+        else if (value instanceof Boolean) {
+            BOOLEAN.writeBoolean(output, (Boolean) value);
+        }
+        else {
+            throw new PrestoException(ELASTICSEARCH_TYPE_MISMATCH, format("Expected a boolean value for field %s of type BOOLEAN: %s [%s]", path, value, value.getClass().getSimpleName()));
+        }
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/decoders/Decoder.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/decoders/Decoder.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch.decoders;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import org.elasticsearch.search.SearchHit;
+
+import java.util.function.Supplier;
+
+public interface Decoder
+{
+    void decode(SearchHit hit, Supplier<Object> getter, BlockBuilder output);
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/decoders/DoubleDecoder.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/decoders/DoubleDecoder.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch.decoders;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.spi.PrestoException;
+import org.elasticsearch.search.SearchHit;
+
+import java.util.function.Supplier;
+
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.elasticsearch.ElasticsearchErrorCode.ELASTICSEARCH_TYPE_MISMATCH;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class DoubleDecoder
+        implements Decoder
+{
+    private final String path;
+
+    public DoubleDecoder(String path)
+    {
+        this.path = requireNonNull(path, "path is null");
+    }
+
+    @Override
+    public void decode(SearchHit hit, Supplier<Object> getter, BlockBuilder output)
+    {
+        Object value = getter.get();
+        if (value == null) {
+            output.appendNull();
+        }
+        else if (value instanceof Number) {
+            DOUBLE.writeDouble(output, ((Number) value).doubleValue());
+        }
+        else {
+            throw new PrestoException(ELASTICSEARCH_TYPE_MISMATCH, format("Expected a numeric value for field %s of type DOUBLE: %s [%s]", path, value, value.getClass().getSimpleName()));
+        }
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/decoders/IdColumnDecoder.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/decoders/IdColumnDecoder.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch.decoders;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import io.airlift.slice.Slices;
+import org.elasticsearch.search.SearchHit;
+
+import java.util.function.Supplier;
+
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+
+public class IdColumnDecoder
+        implements Decoder
+{
+    @Override
+    public void decode(SearchHit hit, Supplier<Object> getter, BlockBuilder output)
+    {
+        VARCHAR.writeSlice(output, Slices.utf8Slice(hit.getId()));
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/decoders/IntegerDecoder.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/decoders/IntegerDecoder.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch.decoders;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.spi.PrestoException;
+import org.elasticsearch.search.SearchHit;
+
+import java.util.function.Supplier;
+
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.elasticsearch.ElasticsearchErrorCode.ELASTICSEARCH_TYPE_MISMATCH;
+import static java.lang.Math.toIntExact;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class IntegerDecoder
+        implements Decoder
+{
+    private final String path;
+
+    public IntegerDecoder(String path)
+    {
+        this.path = requireNonNull(path, "path is null");
+    }
+
+    @Override
+    public void decode(SearchHit hit, Supplier<Object> getter, BlockBuilder output)
+    {
+        Object value = getter.get();
+        if (value == null) {
+            output.appendNull();
+        }
+        else if (value instanceof Number) {
+            INTEGER.writeLong(output, toIntExact(((Number) value).longValue()));
+        }
+        else {
+            throw new PrestoException(ELASTICSEARCH_TYPE_MISMATCH, format("Expected a numeric value for field '%s' of type INTEGER: %s [%s]", path, value, value.getClass().getSimpleName()));
+        }
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/decoders/IpAddressDecoder.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/decoders/IpAddressDecoder.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch.decoders;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.PrestoException;
+import com.google.common.net.InetAddresses;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import org.elasticsearch.search.SearchHit;
+
+import java.util.function.Supplier;
+
+import static com.facebook.presto.elasticsearch.ElasticsearchErrorCode.ELASTICSEARCH_TYPE_MISMATCH;
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static java.lang.String.format;
+import static java.lang.System.arraycopy;
+import static java.util.Objects.requireNonNull;
+
+public class IpAddressDecoder
+        implements Decoder
+{
+    private final String path;
+    private final Type ipAddressType;
+
+    public IpAddressDecoder(String path, Type type)
+    {
+        this.path = requireNonNull(path, "path is null");
+        this.ipAddressType = requireNonNull(type, "type is null");
+    }
+
+    @Override
+    public void decode(SearchHit hit, Supplier<Object> getter, BlockBuilder output)
+    {
+        Object value = getter.get();
+        if (value == null) {
+            output.appendNull();
+        }
+        else if (value instanceof String) {
+            String address = (String) value;
+            Slice slice = castToIpAddress(Slices.utf8Slice(address));
+            ipAddressType.writeSlice(output, slice);
+        }
+        else {
+            throw new PrestoException(ELASTICSEARCH_TYPE_MISMATCH, format("Expected a string value for field '%s' of type IP: %s [%s]", path, value, value.getClass().getSimpleName()));
+        }
+    }
+
+    // This is a copy of IpAddressOperators.castFromVarcharToIpAddress method
+    private Slice castToIpAddress(Slice slice)
+    {
+        byte[] address;
+        try {
+            address = InetAddresses.forString(slice.toStringUtf8()).getAddress();
+        }
+        catch (IllegalArgumentException e) {
+            throw new PrestoException(INVALID_CAST_ARGUMENT, "Cannot cast value to IPADDRESS: " + slice.toStringUtf8());
+        }
+
+        byte[] bytes;
+        if (address.length == 4) {
+            bytes = new byte[16];
+            bytes[10] = (byte) 0xff;
+            bytes[11] = (byte) 0xff;
+            arraycopy(address, 0, bytes, 12, 4);
+        }
+        else if (address.length == 16) {
+            bytes = address;
+        }
+        else {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, "Invalid InetAddress length: " + address.length);
+        }
+
+        return wrappedBuffer(bytes);
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/decoders/RealDecoder.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/decoders/RealDecoder.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch.decoders;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.spi.PrestoException;
+import org.elasticsearch.search.SearchHit;
+
+import java.util.function.Supplier;
+
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.elasticsearch.ElasticsearchErrorCode.ELASTICSEARCH_TYPE_MISMATCH;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class RealDecoder
+        implements Decoder
+{
+    private final String path;
+
+    public RealDecoder(String path)
+    {
+        this.path = requireNonNull(path, "path is null");
+    }
+
+    @Override
+    public void decode(SearchHit hit, Supplier<Object> getter, BlockBuilder output)
+    {
+        Object value = getter.get();
+        if (value == null) {
+            output.appendNull();
+        }
+        else if (value instanceof Number) {
+            REAL.writeLong(output, Float.floatToRawIntBits(((Number) value).floatValue()));
+        }
+        else {
+            throw new PrestoException(ELASTICSEARCH_TYPE_MISMATCH, format("Expected a numeric value for field %s of type REAL: %s [%s]", path, value, value.getClass().getSimpleName()));
+        }
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/decoders/RowDecoder.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/decoders/RowDecoder.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch.decoders;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.spi.PrestoException;
+import org.elasticsearch.search.SearchHit;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static com.facebook.presto.elasticsearch.ElasticsearchErrorCode.ELASTICSEARCH_TYPE_MISMATCH;
+import static com.facebook.presto.elasticsearch.ScanQueryPageSource.getField;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class RowDecoder
+        implements Decoder
+{
+    private final String path;
+    private final List<String> fieldNames;
+    private final List<Decoder> decoders;
+
+    public RowDecoder(String path, List<String> fieldNames, List<Decoder> decoders)
+    {
+        this.path = requireNonNull(path, "path is null");
+        this.fieldNames = fieldNames;
+        this.decoders = decoders;
+    }
+
+    @Override
+    public void decode(SearchHit hit, Supplier<Object> getter, BlockBuilder output)
+    {
+        Object data = getter.get();
+
+        if (data == null) {
+            output.appendNull();
+        }
+        else if (data instanceof Map) {
+            BlockBuilder row = output.beginBlockEntry();
+            for (int i = 0; i < decoders.size(); i++) {
+                String field = fieldNames.get(i);
+                decoders.get(i).decode(hit, () -> getField((Map<String, Object>) data, field), row);
+            }
+            output.closeEntry();
+        }
+        else {
+            throw new PrestoException(ELASTICSEARCH_TYPE_MISMATCH, format("Expected object for field '%s' of type ROW: %s [%s]", path, data, data.getClass().getSimpleName()));
+        }
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/decoders/ScoreColumnDecoder.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/decoders/ScoreColumnDecoder.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch.decoders;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import org.elasticsearch.search.SearchHit;
+
+import java.util.function.Supplier;
+
+import static com.facebook.presto.common.type.RealType.REAL;
+
+public class ScoreColumnDecoder
+        implements Decoder
+{
+    @Override
+    public void decode(SearchHit hit, Supplier<Object> getter, BlockBuilder output)
+    {
+        REAL.writeLong(output, Float.floatToRawIntBits(hit.getScore()));
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/decoders/SmallintDecoder.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/decoders/SmallintDecoder.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch.decoders;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.spi.PrestoException;
+import org.elasticsearch.search.SearchHit;
+
+import java.util.function.Supplier;
+
+import static com.facebook.presto.common.type.SmallintType.SMALLINT;
+import static com.facebook.presto.elasticsearch.ElasticsearchErrorCode.ELASTICSEARCH_TYPE_MISMATCH;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class SmallintDecoder
+        implements Decoder
+{
+    private final String path;
+
+    public SmallintDecoder(String path)
+    {
+        this.path = requireNonNull(path, "path is null");
+    }
+
+    @Override
+    public void decode(SearchHit hit, Supplier<Object> getter, BlockBuilder output)
+    {
+        Object value = getter.get();
+        if (value == null) {
+            output.appendNull();
+        }
+        else if (value instanceof Number) {
+            long decoded = ((Number) value).longValue();
+
+            if (decoded < Short.MIN_VALUE || decoded > Short.MAX_VALUE) {
+                throw new PrestoException(ELASTICSEARCH_TYPE_MISMATCH, format("Value out of range for field '%s' of type SMALLINT: %s", path, decoded));
+            }
+
+            SMALLINT.writeLong(output, decoded);
+        }
+        else {
+            throw new PrestoException(ELASTICSEARCH_TYPE_MISMATCH, format("Expected a numeric value for field '%s' of type SMALLINT: %s [%s]", path, value, value.getClass().getSimpleName()));
+        }
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/decoders/SourceColumnDecoder.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/decoders/SourceColumnDecoder.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch.decoders;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import io.airlift.slice.Slices;
+import org.elasticsearch.search.SearchHit;
+
+import java.util.function.Supplier;
+
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+
+public class SourceColumnDecoder
+        implements Decoder
+{
+    @Override
+    public void decode(SearchHit hit, Supplier<Object> getter, BlockBuilder output)
+    {
+        VARCHAR.writeSlice(output, Slices.utf8Slice(hit.getSourceAsString()));
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/decoders/TimestampDecoder.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/decoders/TimestampDecoder.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch.decoders;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PrestoException;
+import org.elasticsearch.common.document.DocumentField;
+import org.elasticsearch.search.SearchHit;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.function.Supplier;
+
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.elasticsearch.ElasticsearchErrorCode.ELASTICSEARCH_TYPE_MISMATCH;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static java.lang.String.format;
+import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
+import static java.util.Objects.requireNonNull;
+
+public class TimestampDecoder
+        implements Decoder
+{
+    private static final ZoneId ZULU = ZoneId.of("Z");
+
+    private final String path;
+    private final ZoneId zoneId;
+
+    public TimestampDecoder(ConnectorSession session, String path)
+    {
+        this.path = requireNonNull(path, "path is null");
+        this.zoneId = ZoneId.of(session.getSqlFunctionProperties().getTimeZoneKey().getId());
+    }
+
+    @Override
+    public void decode(SearchHit hit, Supplier<Object> getter, BlockBuilder output)
+    {
+        DocumentField documentField = hit.getFields().get(path);
+        Object value = null;
+
+        if (documentField != null) {
+            if (documentField.getValues().size() > 1) {
+                throw new PrestoException(ELASTICSEARCH_TYPE_MISMATCH, format("Expected single value for column '%s', found: %s", path, documentField.getValues().size()));
+            }
+            value = documentField.getValue();
+        }
+        else {
+            value = getter.get();
+        }
+
+        if (value == null) {
+            output.appendNull();
+        }
+        else {
+            LocalDateTime timestamp;
+            if (value instanceof String) {
+                timestamp = ISO_DATE_TIME.parse((String) value, LocalDateTime::from);
+            }
+            else if (value instanceof Number) {
+                timestamp = LocalDateTime.ofInstant(Instant.ofEpochMilli(((Number) value).longValue()), ZULU);
+            }
+            else {
+                throw new PrestoException(NOT_SUPPORTED, format(
+                        "Unsupported representation for field '%s' of type TIMESTAMP: %s [%s]",
+                        path,
+                        value.getClass().getSimpleName(),
+                        value));
+            }
+
+            long epochMillis = timestamp.atZone(zoneId)
+                    .toInstant()
+                    .toEpochMilli();
+
+            TIMESTAMP.writeLong(output, epochMillis);
+        }
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/decoders/TinyintDecoder.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/decoders/TinyintDecoder.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch.decoders;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.spi.PrestoException;
+import org.elasticsearch.search.SearchHit;
+
+import java.util.function.Supplier;
+
+import static com.facebook.presto.common.type.TinyintType.TINYINT;
+import static com.facebook.presto.elasticsearch.ElasticsearchErrorCode.ELASTICSEARCH_TYPE_MISMATCH;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class TinyintDecoder
+        implements Decoder
+{
+    private final String path;
+
+    public TinyintDecoder(String path)
+    {
+        this.path = requireNonNull(path, "path is null");
+    }
+
+    @Override
+    public void decode(SearchHit hit, Supplier<Object> getter, BlockBuilder output)
+    {
+        Object value = getter.get();
+        if (value == null) {
+            output.appendNull();
+        }
+        else if (value instanceof Number) {
+            long decoded = ((Number) value).longValue();
+
+            if (decoded < Byte.MIN_VALUE || decoded > Byte.MAX_VALUE) {
+                throw new PrestoException(ELASTICSEARCH_TYPE_MISMATCH, format("Value out of range for field '%s' of type TINYINT: %s", path, decoded));
+            }
+
+            TINYINT.writeLong(output, decoded);
+        }
+        else {
+            throw new PrestoException(ELASTICSEARCH_TYPE_MISMATCH, format("Expected a numeric value for field '%s' of type TINYINT: %s [%s]", path, value, value.getClass().getSimpleName()));
+        }
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/decoders/VarbinaryDecoder.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/decoders/VarbinaryDecoder.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch.decoders;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.spi.PrestoException;
+import io.airlift.slice.Slices;
+import org.elasticsearch.search.SearchHit;
+
+import java.util.Base64;
+import java.util.function.Supplier;
+
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.elasticsearch.ElasticsearchErrorCode.ELASTICSEARCH_TYPE_MISMATCH;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class VarbinaryDecoder
+        implements Decoder
+{
+    private final String path;
+
+    public VarbinaryDecoder(String path)
+    {
+        this.path = requireNonNull(path, "path is null");
+    }
+
+    @Override
+    public void decode(SearchHit hit, Supplier<Object> getter, BlockBuilder output)
+    {
+        Object value = getter.get();
+        if (value == null) {
+            output.appendNull();
+        }
+        else if (value instanceof String) {
+            VARBINARY.writeSlice(output, Slices.wrappedBuffer(Base64.getDecoder().decode(value.toString())));
+        }
+        else {
+            throw new PrestoException(ELASTICSEARCH_TYPE_MISMATCH, format("Expected a string value for field '%s' of type VARBINARY: %s [%s]", path, value, value.getClass().getSimpleName()));
+        }
+    }
+}

--- a/src/main/java/com/facebook/presto/elasticsearch/decoders/VarcharDecoder.java
+++ b/src/main/java/com/facebook/presto/elasticsearch/decoders/VarcharDecoder.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch.decoders;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.spi.PrestoException;
+import io.airlift.slice.Slices;
+import org.elasticsearch.search.SearchHit;
+
+import java.util.function.Supplier;
+
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.elasticsearch.ElasticsearchErrorCode.ELASTICSEARCH_TYPE_MISMATCH;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class VarcharDecoder
+        implements Decoder
+{
+    private final String path;
+
+    public VarcharDecoder(String path)
+    {
+        this.path = requireNonNull(path, "path is null");
+    }
+
+    @Override
+    public void decode(SearchHit hit, Supplier<Object> getter, BlockBuilder output)
+    {
+        Object value = getter.get();
+        if (value == null) {
+            output.appendNull();
+        }
+        else if (value instanceof String || value instanceof Number) {
+            VARCHAR.writeSlice(output, Slices.utf8Slice(value.toString()));
+        }
+        else {
+            throw new PrestoException(ELASTICSEARCH_TYPE_MISMATCH, format("Expected a string or numeric value for field '%s' of type VARCHAR: %s [%s]", path, value, value.getClass().getSimpleName()));
+        }
+    }
+}

--- a/src/main/resources/META-INF/services/com.facebook.presto.spi.Plugin
+++ b/src/main/resources/META-INF/services/com.facebook.presto.spi.Plugin
@@ -1,0 +1,1 @@
+com.facebook.presto.elasticsearch.Elasticsearch6Plugin

--- a/src/modernizer/violations.xml
+++ b/src/modernizer/violations.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<modernizer>
+    <violation>
+        <name>java/lang/Class.newInstance:()Ljava/lang/Object;</name>
+        <version>1.1</version>
+        <comment>Prefer Class.getConstructor().newInstance()</comment>
+    </violation>
+
+    <violation>
+        <name>java/lang/String.toLowerCase:()Ljava/lang/String;</name>
+        <version>1.1</version>
+        <comment>Prefer String.toLowerCase(java.util.Locale)</comment>
+    </violation>
+
+    <violation>
+        <name>com/google/common/primitives/Ints.checkedCast:(J)I</name>
+        <version>1.8</version>
+        <comment>Prefer Math.toIntExact(long)</comment>
+    </violation>
+
+    <violation>
+        <name>org/testng/Assert.assertEquals:(Ljava/lang/Iterable;Ljava/lang/Iterable;)V</name>
+        <version>1.8</version>
+        <comment>Use com.facebook.presto.testing.assertions.Assert.assertEquals due to TestNG #543</comment>
+    </violation>
+
+    <violation>
+        <name>org/testng/Assert.assertEquals:(Ljava/lang/Iterable;Ljava/lang/Iterable;Ljava/lang/String;)V</name>
+        <version>1.8</version>
+        <comment>Use com.facebook.presto.testing.assertions.Assert.assertEquals due to TestNG #543</comment>
+    </violation>
+
+    <violation>
+        <name>java/util/TimeZone.getTimeZone:(Ljava/lang/String;)Ljava/util/TimeZone;</name>
+        <version>1.8</version>
+        <comment>Avoid TimeZone.getTimeZone as it returns GMT for a zone not supported by the JVM. Use TimeZone.getTimeZone(ZoneId.of(..)) instead, or TimeZone.getTimeZone(..., false).</comment>
+    </violation>
+
+    <violation>
+        <name>org/joda/time/DateTimeZone.toTimeZone:()Ljava/util/TimeZone;</name>
+        <version>1.8</version>
+        <comment>Avoid DateTimeZone.toTimeZone as it returns GMT for a zone not supported by the JVM. Use TimeZone.getTimeZone(ZoneId.of(dtz.getId())) instead.</comment>
+    </violation>
+
+</modernizer>

--- a/src/test/java/com/facebook/presto/elasticsearch/ElasticsearchConnectorTest.java
+++ b/src/test/java/com/facebook/presto/elasticsearch/ElasticsearchConnectorTest.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.MaterializedRow;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestIntegrationSmokeTest;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.net.HostAndPort;
+import io.airlift.tpch.TpchTable;
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.elasticsearch.ElasticsearchQueryRunner.createElasticsearchQueryRunner;
+import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+import static java.lang.String.format;
+
+@Test(singleThreaded = true)
+public class ElasticsearchConnectorTest
+        extends AbstractTestIntegrationSmokeTest
+{
+    private final String elasticsearchServer = "docker.elastic.co/elasticsearch/elasticsearch-oss:6.0.0";
+    private ElasticsearchServer elasticsearch;
+    private RestHighLevelClient client;
+
+    @AfterClass(alwaysRun = true)
+    public final void destroy()
+            throws IOException
+    {
+        elasticsearch.stop();
+        client.close();
+    }
+
+    @Test
+    public void testSelectInformationSchemaForMultiIndexAlias()
+            throws IOException
+    {
+        addAlias("nation", "multi_alias");
+        addAlias("region", "multi_alias");
+
+        // No duplicate entries should be found in information_schema.tables or information_schema.columns.
+        testSelectInformationSchemaTables();
+        testSelectInformationSchemaColumns();
+    }
+
+    @Test
+    public void testSelectInformationSchemaTables()
+    {
+        String catalog = getSession().getCatalog().get();
+        String schema = getSession().getSchema().get();
+        String schemaPattern = schema.replaceAll("^.", "_");
+
+        @Language("SQL") String expectedTables = "VALUES " +
+                "('customer'), " +
+                "('lineitem'), " +
+                "('nation'), " +
+                "('part'), " +
+                "('orders'), " +
+                "('partsupp'), " +
+                "('region'), " +
+                "('supplier'), " +
+                "('multi_alias')";
+
+        assertQuery("SELECT table_name FROM information_schema.tables WHERE table_schema = '" + schema + "'", expectedTables);
+
+        assertQuery("SELECT table_name FROM information_schema.tables WHERE table_schema = '" + schema + "' AND table_name = 'orders'", "VALUES 'orders'");
+        assertQuery("SELECT table_name FROM information_schema.tables WHERE table_schema LIKE '" + schema + "' AND table_name LIKE '%rders'", "VALUES 'orders'");
+        assertQuery("SELECT table_name FROM information_schema.tables WHERE table_schema LIKE '" + schemaPattern + "' AND table_name LIKE '%rders'", "VALUES 'orders'");
+        assertQuery(
+                "SELECT table_name FROM information_schema.tables " +
+                        "WHERE table_catalog = '" + catalog + "' AND table_schema LIKE '" + schema + "' AND table_name LIKE '%orders'",
+                "VALUES 'orders'");
+        assertQuery("SELECT table_name FROM information_schema.tables WHERE table_catalog = 'something_else'", "SELECT '' WHERE false");
+
+        assertQuery(
+                "SELECT DISTINCT table_name FROM information_schema.tables WHERE table_schema = 'information_schema' OR rand() = 42 ORDER BY 1",
+                "VALUES " +
+                        "('applicable_roles'), " +
+                        "('columns'), " +
+                        "('enabled_roles'), " +
+                        "('roles'), " +
+                        "('schemata'), " +
+                        "('table_privileges'), " +
+                        "('tables'), " +
+                        "('views')");
+    }
+
+    @Test
+    public void testSelectInformationSchemaColumns()
+    {
+        String catalog = getSession().getCatalog().get();
+        String schema = getSession().getSchema().get();
+        String schemaPattern = schema.replaceAll(".$", "_");
+
+        @Language("SQL") String ordersTableWithColumns = "VALUES " +
+                "('orders', 'orderkey'), " +
+                "('orders', 'custkey'), " +
+                "('orders', 'orderstatus'), " +
+                "('orders', 'totalprice'), " +
+                "('orders', 'orderdate'), " +
+                "('orders', 'orderpriority'), " +
+                "('orders', 'clerk'), " +
+                "('orders', 'shippriority'), " +
+                "('orders', 'comment')";
+
+        assertQuery("SELECT table_schema FROM information_schema.columns WHERE table_schema = '" + schema + "' GROUP BY table_schema", "VALUES '" + schema + "'");
+        assertQuery("SELECT table_name FROM information_schema.columns WHERE table_name = 'orders' GROUP BY table_name", "VALUES 'orders'");
+        assertQuery("SELECT table_name, column_name FROM information_schema.columns WHERE table_schema = '" + schema + "' AND table_name = 'orders'", ordersTableWithColumns);
+        assertQuery("SELECT table_name, column_name FROM information_schema.columns WHERE table_schema = '" + schema + "' AND table_name LIKE '%rders'", ordersTableWithColumns);
+        assertQuery("SELECT table_name, column_name FROM information_schema.columns WHERE table_schema LIKE '" + schemaPattern + "' AND table_name LIKE '_rder_'", ordersTableWithColumns);
+
+        assertQuerySucceeds("SELECT * FROM information_schema.columns");
+        assertQuery("SELECT DISTINCT table_name, column_name FROM information_schema.columns WHERE table_name LIKE '_rders'", ordersTableWithColumns);
+        assertQuerySucceeds("SELECT * FROM information_schema.columns WHERE table_catalog = '" + catalog + "'");
+        assertQuerySucceeds("SELECT * FROM information_schema.columns WHERE table_catalog = '" + catalog + "' AND table_schema = '" + schema + "'");
+        assertQuery("SELECT table_name, column_name FROM information_schema.columns WHERE table_catalog = '" + catalog + "' AND table_schema = '" + schema + "' AND table_name LIKE '_rders'", ordersTableWithColumns);
+        assertQuerySucceeds("SELECT * FROM information_schema.columns WHERE table_catalog = '" + catalog + "' AND table_name LIKE '%'");
+        assertQuery("SELECT column_name FROM information_schema.columns WHERE table_catalog = 'something_else'", "SELECT '' WHERE false");
+
+        assertQuery(
+                "SELECT DISTINCT table_name FROM information_schema.columns WHERE table_schema = 'information_schema' OR rand() = 42 ORDER BY 1",
+                "VALUES " +
+                        "('applicable_roles'), " +
+                        "('columns'), " +
+                        "('enabled_roles'), " +
+                        "('roles'), " +
+                        "('schemata'), " +
+                        "('table_privileges'), " +
+                        "('tables'), " +
+                        "('views')");
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        elasticsearch = new ElasticsearchServer(elasticsearchServer, ImmutableMap.of());
+        HostAndPort address = elasticsearch.getAddress();
+        client = new RestHighLevelClient(RestClient.builder(new HttpHost(address.getHost(), address.getPort())));
+
+        return createElasticsearchQueryRunner(elasticsearch.getAddress(),
+                TpchTable.getTables(),
+                ImmutableMap.of(),
+                ImmutableMap.of());
+    }
+
+    @Test
+    @Override
+    public void testDescribeTable()
+    {
+        MaterializedResult actualColumns = computeActual("DESC orders").toTestTypes();
+        MaterializedResult.Builder builder = resultBuilder(getQueryRunner().getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR);
+        for (MaterializedRow row : actualColumns.getMaterializedRows()) {
+            builder.row(row.getField(0), row.getField(1), "", "");
+        }
+        MaterializedResult actualResult = builder.build();
+        builder = resultBuilder(getQueryRunner().getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR);
+        MaterializedResult expectedColumns = builder
+                .row("clerk", "varchar", "", "")
+                .row("comment", "varchar", "", "")
+                .row("custkey", "bigint", "", "")
+                .row("orderdate", "timestamp", "", "")
+                .row("orderkey", "bigint", "", "")
+                .row("orderpriority", "varchar", "", "")
+                .row("orderstatus", "varchar", "", "")
+                .row("shippriority", "bigint", "", "")
+                .row("totalprice", "real", "", "")
+                .build();
+        assertEquals(actualResult, expectedColumns, format("%s != %s", actualResult, expectedColumns));
+    }
+
+    @Test
+    public void testMultipleRangesPredicate()
+    {
+        assertQuery("" +
+                "SELECT orderkey, custkey, orderstatus, totalprice, orderdate, orderpriority, clerk, shippriority, comment " +
+                "FROM orders " +
+                "WHERE orderkey BETWEEN 10 AND 50 OR orderkey BETWEEN 100 AND 150");
+    }
+
+    @Test
+    public void testRangePredicate()
+    {
+        // List columns explicitly, as there's no defined order in Elasticsearch
+        assertQuery("" +
+                "SELECT orderkey, custkey, orderstatus, totalprice, orderdate, orderpriority, clerk, shippriority, comment " +
+                "FROM orders " +
+                "WHERE orderkey BETWEEN 10 AND 50");
+    }
+
+    @Test
+    public void testSelectAll()
+    {
+        // List columns explicitly, as there's no defined order in Elasticsearch
+        assertQuery("SELECT orderkey, custkey, orderstatus, totalprice, orderdate, orderpriority, clerk, shippriority, comment  FROM orders");
+    }
+
+    private void addAlias(String index, String alias)
+            throws IOException
+    {
+        client.getLowLevelClient()
+                .performRequest("PUT", format("/%s/_alias/%s", index, alias));
+    }
+}

--- a/src/test/java/com/facebook/presto/elasticsearch/ElasticsearchLoader.java
+++ b/src/test/java/com/facebook/presto/elasticsearch/ElasticsearchLoader.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.client.Column;
+import com.facebook.presto.client.QueryData;
+import com.facebook.presto.client.QueryStatusInfo;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.server.testing.TestingPrestoServer;
+import com.facebook.presto.spi.PrestoWarning;
+import com.facebook.presto.tests.AbstractTestingPrestoClient;
+import com.facebook.presto.tests.ResultsSession;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.DateType.DATE;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.Varchars.isVarcharType;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+
+public class ElasticsearchLoader
+        extends AbstractTestingPrestoClient<Void>
+{
+    private final String tableName;
+    RestHighLevelClient restClient;
+
+    public ElasticsearchLoader(
+            RestHighLevelClient client,
+            String tableName,
+            TestingPrestoServer prestoServer,
+            Session defaultSession)
+    {
+        super(prestoServer, defaultSession);
+
+        this.tableName = requireNonNull(tableName, "tableName is null");
+        this.restClient = requireNonNull(client, "client is null");
+    }
+
+    @Override
+    public ResultsSession<Void> getResultSession(Session session)
+    {
+        requireNonNull(session, "session is null");
+        return new ElasticsearchLoadingSession();
+    }
+
+    private class ElasticsearchLoadingSession
+            implements ResultsSession<Void>
+    {
+        private final AtomicReference<List<Type>> types = new AtomicReference<>();
+
+        private ElasticsearchLoadingSession() {}
+
+        @Override
+        public void setWarnings(List<PrestoWarning> warnings) {}
+
+        @Override
+        public void addResults(QueryStatusInfo statusInfo, QueryData data)
+        {
+            if (types.get() == null && statusInfo.getColumns() != null) {
+                types.set(getTypes(statusInfo.getColumns()));
+            }
+
+            if (data.getData() == null) {
+                return;
+            }
+            checkState(types.get() != null, "Type information is missing");
+            List<Column> columns = statusInfo.getColumns();
+            BulkRequest request = new BulkRequest();
+            for (List<Object> fields : data.getData()) {
+                try {
+                    XContentBuilder dataBuilder = jsonBuilder().startObject();
+                    for (int i = 0; i < fields.size(); i++) {
+                        Type type = types.get().get(i);
+                        Object value = convertValue(fields.get(i), type);
+                        dataBuilder.field(columns.get(i).getName(), value);
+                    }
+                    dataBuilder.endObject();
+                    request.add(new IndexRequest(tableName, "doc").source(dataBuilder));
+                }
+                catch (IOException e) {
+                    throw new UncheckedIOException("Error loading data into Elasticsearch index: " + tableName, e);
+                }
+            }
+            request.setRefreshPolicy(IMMEDIATE);
+            try {
+                restClient.bulk(request);
+            }
+            catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public Void build(Map<String, String> setSessionProperties, Set<String> resetSessionProperties)
+        {
+            return null;
+        }
+
+        private Object convertValue(Object value, Type type)
+        {
+            if (value == null) {
+                return null;
+            }
+
+            if (type == BOOLEAN || type == DATE || isVarcharType(type)) {
+                return value;
+            }
+            if (type == BIGINT) {
+                return ((Number) value).longValue();
+            }
+            if (type == INTEGER) {
+                return ((Number) value).intValue();
+            }
+            if (type.equals(DOUBLE)) {
+                return ((Number) value).doubleValue();
+            }
+            throw new IllegalArgumentException("Unhandled type: " + type);
+        }
+    }
+}

--- a/src/test/java/com/facebook/presto/elasticsearch/ElasticsearchNode.java
+++ b/src/test/java/com/facebook/presto/elasticsearch/ElasticsearchNode.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.node.InternalSettingsPreparer;
+import org.elasticsearch.node.Node;
+import org.elasticsearch.plugins.Plugin;
+
+import java.util.Collection;
+
+public class ElasticsearchNode
+        extends Node
+{
+    public ElasticsearchNode(Settings preparedSettings, Collection<Class<? extends Plugin>> classpathPlugins)
+    {
+        super(InternalSettingsPreparer.prepareEnvironment(preparedSettings, null), classpathPlugins);
+    }
+}

--- a/src/test/java/com/facebook/presto/elasticsearch/ElasticsearchQueryRunner.java
+++ b/src/test/java/com/facebook/presto/elasticsearch/ElasticsearchQueryRunner.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.airlift.log.Logging;
+import com.facebook.presto.Session;
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.facebook.presto.tests.TestingPrestoClient;
+import com.facebook.presto.tpch.TpchPlugin;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.net.HostAndPort;
+import io.airlift.tpch.TpchTable;
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+
+import java.util.Map;
+
+import static com.facebook.airlift.testing.Closeables.closeAllSuppress;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static io.airlift.units.Duration.nanosSince;
+import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public final class ElasticsearchQueryRunner
+{
+    private ElasticsearchQueryRunner() {}
+
+    private static final Logger LOG = Logger.get(ElasticsearchQueryRunner.class);
+    private static final String TPCH_SCHEMA = "tpch";
+    private static final int NODE_COUNT = 2;
+
+    public static DistributedQueryRunner createElasticsearchQueryRunner(
+            HostAndPort address,
+            Iterable<TpchTable<?>> tables,
+            Map<String, String> extraProperties,
+            Map<String, String> extraConnectorProperties)
+            throws Exception
+    {
+        RestHighLevelClient client = null;
+        DistributedQueryRunner queryRunner = null;
+        try {
+            queryRunner = DistributedQueryRunner.builder(createSession())
+                    .setNodeCount(NODE_COUNT)
+                    .setExtraProperties(extraProperties)
+                    .build();
+
+            queryRunner.installPlugin(new TpchPlugin());
+            queryRunner.createCatalog("tpch", "tpch");
+
+            ElasticsearchConnectorFactory testFactory = new ElasticsearchConnectorFactory();
+
+            installElasticsearchPlugin(address, queryRunner, testFactory, extraConnectorProperties);
+
+            TestingPrestoClient prestoClient = queryRunner.getRandomClient();
+
+            LOG.info("Loading data...");
+
+            client = new RestHighLevelClient(RestClient.builder(HttpHost.create(address.toString())));
+
+            long startTime = System.nanoTime();
+            for (TpchTable<?> table : tables) {
+                loadTpchTopic(client, prestoClient, table);
+            }
+            LOG.info("Loading complete in %s", nanosSince(startTime).toString(SECONDS));
+
+            return queryRunner;
+        }
+        catch (Exception e) {
+            closeAllSuppress(e, queryRunner, client);
+            throw e;
+        }
+    }
+
+    private static void installElasticsearchPlugin(
+            HostAndPort address,
+            QueryRunner queryRunner,
+            ElasticsearchConnectorFactory factory,
+            Map<String, String> extraConnectorProperties)
+    {
+        queryRunner.installPlugin(new Elasticsearch6Plugin(factory));
+        Map<String, String> config = ImmutableMap.<String, String>builder()
+                .put("elasticsearch.host", address.getHost())
+                .put("elasticsearch.port", Integer.toString(address.getPort()))
+                // Node discovery relies on the publish_address exposed via the Elasticseach API
+                // This doesn't work well within a docker environment that maps ES's port to a random public port
+                .put("elasticsearch.ignore-publish-address", "true")
+                .put("elasticsearch.default-schema-name", TPCH_SCHEMA)
+                .put("elasticsearch.scroll-size", "1000")
+                .put("elasticsearch.scroll-timeout", "1m")
+                .put("elasticsearch.max-hits", "1000000")
+                .put("elasticsearch.request-timeout", "2m")
+                .putAll(extraConnectorProperties)
+                .build();
+
+        queryRunner.createCatalog("elasticsearch", "elasticsearch_6", config);
+    }
+
+    private static void loadTpchTopic(RestHighLevelClient client, TestingPrestoClient prestoClient, TpchTable<?> table)
+    {
+        long start = System.nanoTime();
+        LOG.info("Running import for %s", table.getTableName());
+        ElasticsearchLoader loader = new ElasticsearchLoader(client, table.getTableName().toLowerCase(ENGLISH), prestoClient.getServer(), prestoClient.getDefaultSession());
+        loader.execute(format("SELECT * from %s", new QualifiedObjectName(TPCH_SCHEMA, TINY_SCHEMA_NAME, table.getTableName().toLowerCase(ENGLISH))));
+        LOG.info("Imported %s in %s", table.getTableName(), nanosSince(start).convertToMostSuccinctTimeUnit());
+    }
+
+    public static Session createSession()
+    {
+        return testSessionBuilder().setCatalog("elasticsearch").setSchema(TPCH_SCHEMA).build();
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        // To start Elasticsearch:
+        // docker run -p 9200:9200 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.6.2
+
+        Logging.initialize();
+
+        DistributedQueryRunner queryRunner = createElasticsearchQueryRunner(
+                HostAndPort.fromParts("localhost", 9200),
+                TpchTable.getTables(),
+                ImmutableMap.of("http-server.http.port", "8080"),
+                ImmutableMap.of());
+        Logger log = Logger.get(ElasticsearchQueryRunner.class);
+        log.info("======== SERVER STARTED ========");
+        log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());
+    }
+}

--- a/src/test/java/com/facebook/presto/elasticsearch/ElasticsearchServer.java
+++ b/src/test/java/com/facebook/presto/elasticsearch/ElasticsearchServer.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.google.common.net.HostAndPort;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static com.google.common.io.Files.createTempDir;
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.testcontainers.utility.MountableFile.forHostPath;
+
+public class ElasticsearchServer
+{
+    private final String containerPath = "/usr/share/elasticsearch/config/";
+    private final Path configurationPath;
+    private final ElasticsearchContainer container;
+
+    public ElasticsearchServer(String image, Map<String, String> configurationFiles)
+            throws IOException
+    {
+        container = new ElasticsearchContainer(image);
+
+        configurationPath = createTempDir().toPath();
+        for (Map.Entry<String, String> entry : configurationFiles.entrySet()) {
+            String name = entry.getKey();
+            byte[] contents = entry.getValue().getBytes(UTF_8);
+
+            Path path = configurationPath.resolve(name);
+            Files.write(path, contents);
+            container.withCopyFileToContainer(forHostPath(path), containerPath + name);
+        }
+
+        container.start();
+    }
+
+    public void stop()
+            throws IOException
+    {
+        container.close();
+        deleteRecursively(configurationPath, ALLOW_INSECURE);
+    }
+
+    public HostAndPort getAddress()
+    {
+        return HostAndPort.fromString(container.getHttpHostAddress());
+    }
+}

--- a/src/test/java/com/facebook/presto/elasticsearch/TestAwsSecurityConfig.java
+++ b/src/test/java/com/facebook/presto/elasticsearch/TestAwsSecurityConfig.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestAwsSecurityConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(AwsSecurityConfig.class)
+                .setAccessKey(null)
+                .setSecretKey(null)
+                .setRegion(null)
+                .setUseInstanceCredentials(false));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("elasticsearch.aws.access-key", "access")
+                .put("elasticsearch.aws.secret-key", "secret")
+                .put("elasticsearch.aws.region", "region")
+                .put("elasticsearch.aws.use-instance-credentials", "true")
+                .build();
+
+        AwsSecurityConfig expected = new AwsSecurityConfig()
+                .setAccessKey("access")
+                .setSecretKey("secret")
+                .setRegion("region")
+                .setUseInstanceCredentials(true);
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/src/test/java/com/facebook/presto/elasticsearch/TestElasticsearchConfig.java
+++ b/src/test/java/com/facebook/presto/elasticsearch/TestElasticsearchConfig.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.Map;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static com.facebook.presto.elasticsearch.ElasticsearchConfig.Security.AWS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class TestElasticsearchConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(ElasticsearchConfig.class)
+                .setHost(null)
+                .setPort(9200)
+                .setDefaultSchema("default")
+                .setScrollSize(1000)
+                .setScrollTimeout(new Duration(1, MINUTES))
+                .setMaxHits(1000)
+                .setRequestTimeout(new Duration(10, SECONDS))
+                .setConnectTimeout(new Duration(1, SECONDS))
+                .setMaxRetryTime(new Duration(30, SECONDS))
+                .setNodeRefreshInterval(new Duration(1, MINUTES))
+                .setMaxHttpConnections(25)
+                .setHttpThreadCount(Runtime.getRuntime().availableProcessors())
+                .setTlsEnabled(false)
+                .setKeystorePath(null)
+                .setKeystorePassword(null)
+                .setTrustStorePath(null)
+                .setTruststorePassword(null)
+                .setVerifyHostnames(true)
+                .setIgnorePublishAddress(false)
+                .setSecurity(null));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("elasticsearch.host", "example.com")
+                .put("elasticsearch.port", "9999")
+                .put("elasticsearch.default-schema-name", "test")
+                .put("elasticsearch.scroll-size", "4000")
+                .put("elasticsearch.scroll-timeout", "20s")
+                .put("elasticsearch.max-hits", "20000")
+                .put("elasticsearch.request-timeout", "1s")
+                .put("elasticsearch.connect-timeout", "10s")
+                .put("elasticsearch.max-retry-time", "10s")
+                .put("elasticsearch.node-refresh-interval", "10m")
+                .put("elasticsearch.max-http-connections", "100")
+                .put("elasticsearch.http-thread-count", "30")
+                .put("elasticsearch.tls.enabled", "true")
+                .put("elasticsearch.tls.keystore-path", "/tmp/keystore")
+                .put("elasticsearch.tls.keystore-password", "keystore-password")
+                .put("elasticsearch.tls.truststore-path", "/tmp/truststore")
+                .put("elasticsearch.tls.truststore-password", "truststore-password")
+                .put("elasticsearch.tls.verify-hostnames", "false")
+                .put("elasticsearch.ignore-publish-address", "true")
+                .put("elasticsearch.security", "AWS")
+                .build();
+
+        ElasticsearchConfig expected = new ElasticsearchConfig()
+                .setHost("example.com")
+                .setPort(9999)
+                .setDefaultSchema("test")
+                .setScrollSize(4000)
+                .setScrollTimeout(new Duration(20, SECONDS))
+                .setMaxHits(20000)
+                .setRequestTimeout(new Duration(1, SECONDS))
+                .setConnectTimeout(new Duration(10, SECONDS))
+                .setMaxRetryTime(new Duration(10, SECONDS))
+                .setNodeRefreshInterval(new Duration(10, MINUTES))
+                .setMaxHttpConnections(100)
+                .setHttpThreadCount(30)
+                .setTlsEnabled(true)
+                .setKeystorePath(new File("/tmp/keystore"))
+                .setKeystorePassword("keystore-password")
+                .setTrustStorePath(new File("/tmp/truststore"))
+                .setTruststorePassword("truststore-password")
+                .setVerifyHostnames(false)
+                .setIgnorePublishAddress(true)
+                .setSecurity(AWS);
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/src/test/java/com/facebook/presto/elasticsearch/TestElasticsearchIntegrationSmokeTest.java
+++ b/src/test/java/com/facebook/presto/elasticsearch/TestElasticsearchIntegrationSmokeTest.java
@@ -1,0 +1,808 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.MaterializedRow;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestIntegrationSmokeTest;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.BaseEncoding;
+import com.google.common.net.HostAndPort;
+import io.airlift.tpch.TpchTable;
+import org.apache.http.HttpHost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.nio.entity.NStringEntity;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.elasticsearch.ElasticsearchQueryRunner.createElasticsearchQueryRunner;
+import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Test(singleThreaded = true)
+public class TestElasticsearchIntegrationSmokeTest
+        extends AbstractTestIntegrationSmokeTest
+{
+    private final String elasticsearchServer = "docker.elastic.co/elasticsearch/elasticsearch-oss:6.0.0";
+    private ElasticsearchServer elasticsearch;
+    private RestHighLevelClient client;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        elasticsearch = new ElasticsearchServer(elasticsearchServer, ImmutableMap.of());
+
+        HostAndPort address = elasticsearch.getAddress();
+        client = new RestHighLevelClient(RestClient.builder(new HttpHost(address.getHost(), address.getPort())));
+
+        return createElasticsearchQueryRunner(elasticsearch.getAddress(),
+                TpchTable.getTables(),
+                ImmutableMap.of(),
+                ImmutableMap.of());
+    }
+
+    @AfterClass(alwaysRun = true)
+    public final void destroy()
+            throws IOException
+    {
+        elasticsearch.stop();
+        client.close();
+    }
+
+    @Test
+    public void testSelectAll()
+    {
+        // List columns explicitly, as there's no defined order in Elasticsearch
+        assertQuery("SELECT orderkey, custkey, orderstatus, totalprice, orderdate, orderpriority, clerk, shippriority, comment  FROM orders");
+    }
+
+    @Test
+    public void testRangePredicate()
+    {
+        // List columns explicitly, as there's no defined order in Elasticsearch
+        assertQuery("" +
+                "SELECT orderkey, custkey, orderstatus, totalprice, orderdate, orderpriority, clerk, shippriority, comment " +
+                "FROM orders " +
+                "WHERE orderkey BETWEEN 10 AND 50");
+    }
+
+    @Test
+    public void testCountAll()
+    {
+        assertQuery("SELECT COUNT(*) FROM orders");
+        assertQuery("SELECT count(*) FROM orders WHERE orderkey > 10");
+        assertQuery("SELECT count(*) FROM (SELECT * FROM orders LIMIT 10)");
+        assertQuery("SELECT count(*) FROM (SELECT * FROM orders WHERE orderkey > 10 LIMIT 10)");
+    }
+
+    @Test
+    public void testMultipleRangesPredicate()
+    {
+        assertQuery("" +
+                "SELECT orderkey, custkey, orderstatus, totalprice, orderdate, orderpriority, clerk, shippriority, comment " +
+                "FROM orders " +
+                "WHERE orderkey BETWEEN 10 AND 50 OR orderkey BETWEEN 100 AND 150");
+    }
+
+    @Test
+    @Override
+    public void testDescribeTable()
+    {
+        MaterializedResult actualColumns = computeActual("DESC orders").toTestTypes();
+        MaterializedResult.Builder builder = resultBuilder(getQueryRunner().getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR);
+        for (MaterializedRow row : actualColumns.getMaterializedRows()) {
+            builder.row(row.getField(0), row.getField(1), "", "");
+        }
+        MaterializedResult actualResult = builder.build();
+        builder = resultBuilder(getQueryRunner().getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR);
+        MaterializedResult expectedColumns = builder
+                .row("clerk", "varchar", "", "")
+                .row("comment", "varchar", "", "")
+                .row("custkey", "bigint", "", "")
+                .row("orderdate", "timestamp", "", "")
+                .row("orderkey", "bigint", "", "")
+                .row("orderpriority", "varchar", "", "")
+                .row("orderstatus", "varchar", "", "")
+                .row("shippriority", "bigint", "", "")
+                .row("totalprice", "real", "", "")
+                .build();
+        assertEquals(actualResult, expectedColumns, format("%s != %s", actualResult, expectedColumns));
+    }
+
+    @Test
+    public void testShowCreateTable()
+    {
+        assertThat(computeActual("SHOW CREATE TABLE orders").getOnlyValue())
+                .isEqualTo("CREATE TABLE elasticsearch.tpch.orders (\n" +
+                        "   \"clerk\" varchar,\n" +
+                        "   \"comment\" varchar,\n" +
+                        "   \"custkey\" bigint,\n" +
+                        "   \"orderdate\" timestamp,\n" +
+                        "   \"orderkey\" bigint,\n" +
+                        "   \"orderpriority\" varchar,\n" +
+                        "   \"orderstatus\" varchar,\n" +
+                        "   \"shippriority\" bigint,\n" +
+                        "   \"totalprice\" real\n" +
+                        ")");
+    }
+
+    @Test
+    public void testArrayFields()
+            throws IOException
+    {
+        String indexName = "test_arrays";
+
+        String mapping = "" +
+                "{" +
+                "  \"mappings\": {" +
+                "    \"doc\": {" +
+                "      \"_meta\": {" +
+                "        \"presto\": {" +
+                "          \"a\": {" +
+                "            \"b\": {" +
+                "              \"y\": {" +
+                "                \"isArray\": true" +
+                "              }" +
+                "            }" +
+                "          }," +
+                "          \"c\": {" +
+                "            \"f\": {" +
+                "              \"g\": {" +
+                "                \"isArray\": true" +
+                "              }," +
+                "              \"isArray\": true" +
+                "            }" +
+                "          }," +
+                "          \"j\": {" +
+                "            \"isArray\": true" +
+                "          }," +
+                "          \"k\": {" +
+                "            \"isArray\": true" +
+                "          }" +
+                "        }" +
+                "      }," +
+                "      \"properties\":{" +
+                "        \"a\": {" +
+                "          \"type\": \"object\"," +
+                "          \"properties\": {" +
+                "            \"b\": {" +
+                "              \"type\": \"object\"," +
+                "              \"properties\": {" +
+                "                \"x\": {" +
+                "                  \"type\": \"integer\"" +
+                "                }," +
+                "                \"y\": {" +
+                "                  \"type\": \"keyword\"" +
+                "                }" +
+                "              } " +
+                "            }" +
+                "          }" +
+                "        }," +
+                "        \"c\": {" +
+                "          \"type\": \"object\"," +
+                "          \"properties\": {" +
+                "            \"d\": {" +
+                "              \"type\": \"keyword\"" +
+                "            }," +
+                "            \"e\": {" +
+                "              \"type\": \"keyword\"" +
+                "            }," +
+                "            \"f\": {" +
+                "              \"type\": \"object\"," +
+                "              \"properties\": {" +
+                "                \"g\": {" +
+                "                  \"type\": \"integer\"" +
+                "                }," +
+                "                \"h\": {" +
+                "                  \"type\": \"integer\"" +
+                "                }" +
+                "              } " +
+                "            }" +
+                "          }" +
+                "        }," +
+                "        \"i\": {" +
+                "          \"type\": \"long\"" +
+                "        }," +
+                "        \"j\": {" +
+                "          \"type\": \"long\"" +
+                "        }," +
+                "        \"k\": {" +
+                "          \"type\": \"long\"" +
+                "        }" +
+                "      }" +
+                "    }" +
+                "  }" +
+                "}";
+
+        createIndex(indexName, mapping);
+
+        index(indexName, ImmutableMap.<String, Object>builder()
+                .put("a", ImmutableMap.<String, Object>builder()
+                        .put("b", ImmutableMap.<String, Object>builder()
+                                .put("x", 1)
+                                .put("y", ImmutableList.<String>builder()
+                                        .add("hello")
+                                        .add("world")
+                                        .build())
+                                .build())
+                        .build())
+                .put("c", ImmutableMap.<String, Object>builder()
+                        .put("d", "foo")
+                        .put("e", "bar")
+                        .put("f", ImmutableList.<Map<String, Object>>builder()
+                                .add(ImmutableMap.<String, Object>builder()
+                                        .put("g", ImmutableList.<Integer>builder()
+                                                .add(10)
+                                                .add(20)
+                                                .build())
+                                        .put("h", 100)
+                                        .build())
+                                .add(ImmutableMap.<String, Object>builder()
+                                        .put("g", ImmutableList.<Integer>builder()
+                                                .add(30)
+                                                .add(40)
+                                                .build())
+                                        .put("h", 200)
+                                        .build())
+                                .build())
+                        .build())
+                .put("j", ImmutableList.<Long>builder()
+                        .add(50L)
+                        .add(60L)
+                        .build())
+                .build());
+
+        assertQuery(
+                "SELECT a.b.y[1], c.f[1].g[2], c.f[2].g[1], j[2], k[1] FROM test_arrays",
+                "VALUES ('hello', 20, 30, 60, NULL)");
+    }
+
+    @Test
+    public void testEmptyObjectFields()
+            throws IOException
+    {
+        String indexName = "emptyobject";
+        index(indexName, ImmutableMap.<String, Object>builder()
+                .put("name", "stringfield")
+                .put("emptyobject", ImmutableMap.of())
+                .put("fields.fielda", 32)
+                .put("fields.fieldb", ImmutableMap.of())
+                .build());
+
+        assertQuery(
+                "SELECT name, fields.fielda FROM emptyobject",
+                "VALUES ('stringfield', 32)");
+    }
+
+    @Test
+    public void testNestedFields()
+            throws IOException
+    {
+        String indexName = "data";
+        index(indexName, ImmutableMap.<String, Object>builder()
+                .put("name", "nestfield")
+                .put("fields.fielda", 32)
+                .put("fields.fieldb", "valueb")
+                .build());
+
+        assertQuery(
+                "SELECT name, fields.fielda, fields.fieldb FROM data",
+                "VALUES ('nestfield', 32, 'valueb')");
+    }
+
+    @Test
+    public void testNestedVariants()
+            throws IOException
+    {
+        String indexName = "nested_variants";
+
+        index(indexName,
+                ImmutableMap.of("a",
+                        ImmutableMap.of("b",
+                                ImmutableMap.of("c",
+                                        "value1"))));
+
+        index(indexName,
+                ImmutableMap.of("a.b",
+                        ImmutableMap.of("c",
+                                "value2")));
+
+        index(indexName,
+                ImmutableMap.of("a",
+                        ImmutableMap.of("b.c",
+                                "value3")));
+
+        index(indexName,
+                ImmutableMap.of("a.b.c", "value4"));
+
+        assertQuery(
+                "SELECT a.b.c FROM nested_variants",
+                "VALUES 'value1', 'value2', 'value3', 'value4'");
+    }
+
+    @Test
+    public void testDataTypes()
+            throws IOException
+    {
+        String indexName = "types";
+
+        String mapping = "" +
+                "{" +
+                "  \"mappings\": {" +
+                "    \"doc\": {" +
+                "      \"properties\": {" +
+                "        \"boolean_column\":   { \"type\": \"boolean\" }," +
+                "        \"float_column\":     { \"type\": \"float\" }," +
+                "        \"double_column\":    { \"type\": \"double\" }," +
+                "        \"integer_column\":   { \"type\": \"integer\" }," +
+                "        \"long_column\":      { \"type\": \"long\" }," +
+                "        \"keyword_column\":   { \"type\": \"keyword\" }," +
+                "        \"text_column\":      { \"type\": \"text\" }," +
+                "        \"binary_column\":    { \"type\": \"binary\" }," +
+                "        \"timestamp_column\": { \"type\": \"date\" }" +
+                "      }" +
+                "    }" +
+                "  }" +
+                "}";
+
+        createIndex(indexName, mapping);
+
+        index(indexName, ImmutableMap.<String, Object>builder()
+                .put("boolean_column", true)
+                .put("float_column", 1.0f)
+                .put("double_column", 1.0d)
+                .put("integer_column", 1)
+                .put("long_column", 1L)
+                .put("keyword_column", "cool")
+                .put("text_column", "some text")
+                .put("binary_column", new byte[] {(byte) 0xCA, (byte) 0xFE})
+                .put("timestamp_column", 0)
+                .put("ipv4_column", "192.0.2.4")
+                .put("ipv6_column", "2001:db8:0:1:1:1:1:1")
+                .build());
+
+        MaterializedResult rows = computeActual("" +
+                "SELECT " +
+                "boolean_column, " +
+                "float_column, " +
+                "double_column, " +
+                "integer_column, " +
+                "long_column, " +
+                "keyword_column, " +
+                "text_column, " +
+                "binary_column, " +
+                "timestamp_column, " +
+                "ipv4_column, " +
+                "ipv6_column " +
+                "FROM types");
+
+        MaterializedResult expected = resultBuilder(getSession(), rows.getTypes())
+                .row(true, 1.0f, 1.0d, 1, 1L, "cool", "some text", new byte[] {(byte) 0xCA, (byte) 0xFE},
+                        LocalDateTime.of(1970, 1, 1, 0, 0), "192.0.2.4", "2001:db8:0:1:1:1:1:1")
+                .build();
+
+        assertEquals(rows.getMaterializedRows(), expected.getMaterializedRows());
+    }
+
+    @Test
+    public void testFilters()
+            throws IOException
+    {
+        String indexName = "filter_pushdown";
+
+        String mapping = "" +
+                "{" +
+                "  \"mappings\": {" +
+                "    \"doc\": {" +
+                "      \"properties\": {" +
+                "        \"boolean_column\":   { \"type\": \"boolean\" }," +
+                "        \"float_column\":     { \"type\": \"float\" }," +
+                "        \"double_column\":    { \"type\": \"double\" }," +
+                "        \"integer_column\":   { \"type\": \"integer\" }," +
+                "        \"long_column\":      { \"type\": \"long\" }," +
+                "        \"keyword_column\":   { \"type\": \"keyword\" }," +
+                "        \"text_column\":      { \"type\": \"text\" }," +
+                "        \"binary_column\":    { \"type\": \"binary\" }," +
+                "        \"timestamp_column\": { \"type\": \"date\" }" +
+                "      }" +
+                "    }" +
+                "  }" +
+                "}";
+
+        createIndex(indexName, mapping);
+
+        index(indexName, ImmutableMap.<String, Object>builder()
+                .put("boolean_column", true)
+                .put("byte_column", 1)
+                .put("short_column", 2)
+                .put("integer_column", 3)
+                .put("long_column", 4L)
+                .put("float_column", 1.0f)
+                .put("double_column", 1.0d)
+                .put("keyword_column", "cool")
+                .put("text_column", "some text")
+                .put("binary_column", new byte[] {(byte) 0xCA, (byte) 0xFE})
+                .put("timestamp_column", 1569888000000L)
+                .put("ipv4_column", "192.0.2.4")
+                .put("ipv6_column", "2001:db8:0:1:1:1:1:1")
+                .build());
+
+        // boolean
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE boolean_column = true", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE boolean_column = false", "VALUES 0");
+
+        // tinyint
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE byte_column = 1", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE byte_column = 0", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE byte_column > 1", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE byte_column < 1", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE byte_column > 0", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE byte_column < 10", "VALUES 1");
+
+        // smallint
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE short_column = 2", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE short_column > 2", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE short_column < 2", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE short_column = 0", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE short_column > 0", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE short_column < 10", "VALUES 1");
+
+        // integer
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE integer_column = 3", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE integer_column > 3", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE integer_column < 3", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE integer_column = 0", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE integer_column > 0", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE integer_column < 10", "VALUES 1");
+
+        // bigint
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE long_column = 4", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE long_column > 4", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE long_column < 4", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE long_column = 0", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE long_column > 0", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE long_column < 10", "VALUES 1");
+
+        // real
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE float_column = 1.0", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE float_column > 1.0", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE float_column < 1.0", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE float_column = 0.0", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE float_column > 0.0", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE float_column < 10.0", "VALUES 1");
+
+        // double
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE double_column = 1.0", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE double_column > 1.0", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE double_column < 1.0", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE double_column = 0.0", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE double_column > 0.0", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE double_column < 10.0", "VALUES 1");
+
+        // varchar
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE keyword_column = 'cool'", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE keyword_column = 'bar'", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE text_column = 'some'", "VALUES 0");
+
+        // timestamp
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE timestamp_column = TIMESTAMP '2019-10-01 00:00:00'", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE timestamp_column > TIMESTAMP '2019-10-01 00:00:00'", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE timestamp_column < TIMESTAMP '2019-10-01 00:00:00'", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE timestamp_column = TIMESTAMP '2019-10-02 00:00:00'", "VALUES 0");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE timestamp_column > TIMESTAMP '2001-01-01 00:00:00'", "VALUES 1");
+        assertQuery("SELECT count(*) FROM filter_pushdown WHERE timestamp_column < TIMESTAMP '2030-01-01 00:00:00'", "VALUES 1");
+
+        // ipaddress
+        assertQuery("SELECT count(ipv4_column) FROM filter_pushdown", "VALUES 1");
+        assertQuery("SELECT count(ipv6_column) FROM filter_pushdown", "VALUES 1");
+    }
+
+    @Test
+    public void testDataTypesNested()
+            throws IOException
+    {
+        String indexName = "types_nested";
+
+        String mapping = "" +
+                "{" +
+                "  \"mappings\": {" +
+                "    \"doc\": {" +
+                "      \"properties\": {" +
+                "        \"field\": {" +
+                "          \"properties\": {" +
+                "            \"boolean_column\":   { \"type\": \"boolean\" }," +
+                "            \"float_column\":     { \"type\": \"float\" }," +
+                "            \"double_column\":    { \"type\": \"double\" }," +
+                "            \"integer_column\":   { \"type\": \"integer\" }," +
+                "            \"long_column\":      { \"type\": \"long\" }," +
+                "            \"keyword_column\":   { \"type\": \"keyword\" }," +
+                "            \"text_column\":      { \"type\": \"text\" }," +
+                "            \"binary_column\":    { \"type\": \"binary\" }," +
+                "            \"timestamp_column\": { \"type\": \"date\" }" +
+                "          }" +
+                "        }" +
+                "      }" +
+                "    }" +
+                "  }" +
+                "}";
+
+        createIndex(indexName, mapping);
+
+        index(indexName, ImmutableMap.of(
+                "field",
+                ImmutableMap.<String, Object>builder()
+                        .put("boolean_column", true)
+                        .put("float_column", 1.0f)
+                        .put("double_column", 1.0d)
+                        .put("integer_column", 1)
+                        .put("long_column", 1L)
+                        .put("keyword_column", "cool")
+                        .put("text_column", "some text")
+                        .put("binary_column", new byte[] {(byte) 0xCA, (byte) 0xFE})
+                        .put("timestamp_column", 0)
+                        .put("ipv4_column", "192.0.2.4")
+                        .put("ipv6_column", "2001:db8:0:1:1:1:1:1")
+                        .build()));
+
+        MaterializedResult rows = computeActual("" +
+                "SELECT " +
+                "field.boolean_column, " +
+                "field.float_column, " +
+                "field.double_column, " +
+                "field.integer_column, " +
+                "field.long_column, " +
+                "field.keyword_column, " +
+                "field.text_column, " +
+                "field.binary_column, " +
+                "field.timestamp_column, " +
+                "field.ipv4_column, " +
+                "field.ipv6_column " +
+                "FROM types_nested");
+
+        MaterializedResult expected = resultBuilder(getSession(), rows.getTypes())
+                .row(true, 1.0f, 1.0d, 1, 1L, "cool", "some text", new byte[] {(byte) 0xCA, (byte) 0xFE},
+                        LocalDateTime.of(1970, 1, 1, 0, 0), "192.0.2.4", "2001:db8:0:1:1:1:1:1")
+                .build();
+
+        assertEquals(rows.getMaterializedRows(), expected.getMaterializedRows());
+    }
+
+    @Test
+    public void testNestedTypeDataTypesNested()
+            throws IOException
+    {
+        String indexName = "nested_type_nested";
+
+        String mapping = "" +
+                "{" +
+                "  \"mappings\": {" +
+                "    \"doc\": {" +
+                "      \"properties\": {" +
+                "        \"nested_field\": {" +
+                "          \"type\":\"nested\"," +
+                "          \"properties\": {" +
+                "            \"boolean_column\":   { \"type\": \"boolean\" }," +
+                "            \"float_column\":     { \"type\": \"float\" }," +
+                "            \"double_column\":    { \"type\": \"double\" }," +
+                "            \"integer_column\":   { \"type\": \"integer\" }," +
+                "            \"long_column\":      { \"type\": \"long\" }," +
+                "            \"keyword_column\":   { \"type\": \"keyword\" }," +
+                "            \"text_column\":      { \"type\": \"text\" }," +
+                "            \"binary_column\":    { \"type\": \"binary\" }," +
+                "            \"timestamp_column\": { \"type\": \"date\" }," +
+                "            \"ipv4_column\":      { \"type\": \"ip\" }," +
+                "            \"ipv6_column\":      { \"type\": \"ip\" }" +
+                "          }" +
+                "        }" +
+                "      }" +
+                "    }" +
+                "  }" +
+                "}";
+
+        createIndex(indexName, mapping);
+
+        index(indexName, ImmutableMap.of(
+                "nested_field",
+                ImmutableMap.<String, Object>builder()
+                        .put("boolean_column", true)
+                        .put("float_column", 1.0f)
+                        .put("double_column", 1.0d)
+                        .put("integer_column", 1)
+                        .put("long_column", 1L)
+                        .put("keyword_column", "cool")
+                        .put("text_column", "some text")
+                        .put("binary_column", new byte[] {(byte) 0xCA, (byte) 0xFE})
+                        .put("timestamp_column", 0)
+                        .put("ipv4_column", "192.0.2.4")
+                        .put("ipv6_column", "2001:db8:0:1:1:1:1:1")
+                        .build()));
+
+        MaterializedResult rows = computeActual("" +
+                "SELECT " +
+                "nested_field.boolean_column, " +
+                "nested_field.float_column, " +
+                "nested_field.double_column, " +
+                "nested_field.integer_column, " +
+                "nested_field.long_column, " +
+                "nested_field.keyword_column, " +
+                "nested_field.text_column, " +
+                "nested_field.binary_column, " +
+                "nested_field.timestamp_column, " +
+                "nested_field.ipv4_column, " +
+                "nested_field.ipv6_column " +
+                "FROM nested_type_nested");
+
+        MaterializedResult expected = resultBuilder(getSession(), rows.getTypes())
+                .row(true, 1.0f, 1.0d, 1, 1L, "cool", "some text", new byte[] {(byte) 0xCA, (byte) 0xFE},
+                        LocalDateTime.of(1970, 1, 1, 0, 0), "192.0.2.4", "2001:db8:0:1:1:1:1:1")
+                .build();
+
+        assertEquals(rows.getMaterializedRows(), expected.getMaterializedRows());
+    }
+
+    @Test
+    public void testQueryString()
+    {
+        MaterializedResult actual = computeActual("SELECT count(*) FROM \"orders: +packages -slyly\"");
+
+        MaterializedResult expected = resultBuilder(getSession(), ImmutableList.of(BIGINT))
+                .row(1639L)
+                .build();
+
+        assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testMixedCase()
+            throws IOException
+    {
+        String indexName = "mixed_case";
+        index(indexName, ImmutableMap.<String, Object>builder()
+                .put("Name", "john")
+                .put("AGE", 32)
+                .build());
+
+        assertQuery(
+                "SELECT name, age FROM mixed_case",
+                "VALUES ('john', 32)");
+
+        assertQuery(
+                "SELECT name, age FROM mixed_case WHERE name = 'john'",
+                "VALUES ('john', 32)");
+    }
+
+    @Test
+    public void testNumericKeyword()
+            throws IOException
+    {
+        String indexName = "numeric_keyword";
+
+        index(indexName, ImmutableMap.<String, Object>builder()
+                .put("numeric_column", 20)
+                .build());
+
+        assertQuery(
+                "SELECT numeric_column FROM numeric_keyword",
+                "VALUES 20");
+        assertQuery(
+                "SELECT numeric_column FROM numeric_keyword where numeric_column = 20",
+                "VALUES 20");
+    }
+
+    @Test
+    public void testQueryStringError()
+    {
+        assertQueryFails("SELECT orderkey FROM \"orders: ++foo AND\"", "\\QFailed to parse query [ ++foo and]\\E");
+        assertQueryFails("SELECT count(*) FROM \"orders: ++foo AND\"", "\\QFailed to parse query [ ++foo and]\\E");
+    }
+
+    @Test
+    public void testAlias()
+            throws IOException
+    {
+        addAlias("orders", "orders_alias");
+
+        assertQuery(
+                "SELECT count(*) FROM orders_alias",
+                "SELECT count(*) FROM orders");
+
+        removeAlias("orders", "orders_alias");
+    }
+
+    @Test(enabled = false)
+    public void testMultiIndexAlias()
+            throws IOException
+    {
+        addAlias("nation", "multi_alias");
+        addAlias("region", "multi_alias");
+
+        assertQuery(
+                "SELECT count(*) FROM multi_alias",
+                "SELECT (SELECT count(*) FROM region) + (SELECT count(*) FROM nation)");
+    }
+
+    private void index(String index, Map<String, Object> document)
+            throws IOException
+    {
+        client.index(new IndexRequest(index, "doc")
+                .source(document)
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE));
+    }
+
+    @Test
+    public void testPassthroughQuery()
+    {
+        @Language("JSON")
+        String query = "{\n" +
+                "    \"size\": 0,\n" +
+                "    \"aggs\" : {\n" +
+                "        \"max_orderkey\" : { \"max\" : { \"field\" : \"orderkey\" } },\n" +
+                "        \"sum_orderkey\" : { \"sum\" : { \"field\" : \"orderkey\" } }\n" +
+                "    }\n" +
+                "}";
+
+        assertQuery(
+                format("WITH data(r) AS (" +
+                        "   SELECT CAST(result AS ROW(aggregations ROW(max_orderkey ROW(value BIGINT), sum_orderkey ROW(value BIGINT)))) " +
+                        "   FROM \"orders$query:%s\") " +
+                        "SELECT r.aggregations.max_orderkey.value, r.aggregations.sum_orderkey.value " +
+                        "FROM data", BaseEncoding.base32().encode(query.getBytes(UTF_8))),
+                "VALUES (60000, 449872500)");
+
+        assertQueryFails(
+                "SELECT * FROM \"orders$query:invalid-base32-encoding\"",
+                "Elasticsearch query for 'orders' is not base32-encoded correctly");
+        assertQueryFails(
+                format("SELECT * FROM \"orders$query:%s\"", BaseEncoding.base32().encode("invalid json".getBytes(UTF_8))),
+                "Elasticsearch query for 'orders' is not valid JSON");
+    }
+
+    private void addAlias(String index, String alias)
+            throws IOException
+    {
+        client.getLowLevelClient()
+                .performRequest("PUT", format("/%s/_alias/%s", index, alias));
+    }
+
+    private void removeAlias(String index, String alias)
+            throws IOException
+    {
+        client.getLowLevelClient()
+                .performRequest("DELETE", format("/%s/_alias/%s", index, alias));
+    }
+
+    private void createIndex(String indexName, @Language("JSON") String mapping)
+            throws IOException
+    {
+        client.getLowLevelClient()
+                .performRequest("PUT", "/" + indexName, ImmutableMap.of(), new NStringEntity(mapping, ContentType.APPLICATION_JSON));
+    }
+}

--- a/src/test/java/com/facebook/presto/elasticsearch/TestPasswordAuthentication.java
+++ b/src/test/java/com/facebook/presto/elasticsearch/TestPasswordAuthentication.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.amazonaws.util.Base64;
+import com.facebook.presto.sql.query.QueryAssertions;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.Resources;
+import com.google.common.net.HostAndPort;
+import org.apache.http.HttpHost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.nio.entity.NStringEntity;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static com.facebook.presto.elasticsearch.ElasticsearchQueryRunner.createElasticsearchQueryRunner;
+import static com.google.common.io.Resources.getResource;
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class TestPasswordAuthentication
+{
+    // We use 7.8.0 because security became a non-commercial feature in recent versions
+    private final String elasticsearchImage = "docker.elastic.co/elasticsearch/elasticsearch:7.8.0";
+    private static final String USER = "elastic_user";
+    private static final String PASSWORD = "123456";
+
+    private final ElasticsearchServer elasticsearch;
+    private final RestHighLevelClient client;
+    private final QueryAssertions assertions;
+
+    public TestPasswordAuthentication()
+            throws Exception
+    {
+        elasticsearch = new ElasticsearchServer(elasticsearchImage, ImmutableMap.<String, String>builder()
+                .put("elasticsearch.yml", loadResource("elasticsearch.yml"))
+                .put("users", loadResource("users"))
+                .put("users_roles", loadResource("users_roles"))
+                .put("roles.yml", loadResource("roles.yml"))
+                .build());
+
+        HostAndPort address = elasticsearch.getAddress();
+        client = new RestHighLevelClient(RestClient.builder(new HttpHost(address.getHost(), address.getPort())));
+
+        DistributedQueryRunner runner = createElasticsearchQueryRunner(
+                elasticsearch.getAddress(),
+                ImmutableList.of(),
+                ImmutableMap.of(),
+                ImmutableMap.<String, String>builder()
+                        .put("elasticsearch.security", "PASSWORD")
+                        .put("elasticsearch.auth.user", USER)
+                        .put("elasticsearch.auth.password", PASSWORD)
+                        .build());
+
+        assertions = new QueryAssertions(runner);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public final void destroy()
+            throws IOException
+    {
+        assertions.close();
+        elasticsearch.stop();
+        client.close();
+    }
+
+    @Test
+    public void test()
+            throws IOException
+    {
+        String json = new ObjectMapper().writeValueAsString(ImmutableMap.<String, Object>builder()
+                .put("value", 42L)
+                .build());
+
+        client.getLowLevelClient()
+                .performRequest(
+                        "POST",
+                        "/test/_doc?refresh",
+                        ImmutableMap.of(),
+                        new NStringEntity(json, ContentType.APPLICATION_JSON),
+                        new BasicHeader("Authorization", format("Basic %s", Base64.encodeAsString(format("%s:%s", USER, PASSWORD).getBytes(StandardCharsets.UTF_8)))));
+
+        assertions.assertQuery("SELECT * FROM test",
+                "VALUES BIGINT '42'");
+    }
+
+    private static String loadResource(String file)
+            throws IOException
+    {
+        return Resources.toString(getResource(file), UTF_8);
+    }
+}

--- a/src/test/java/com/facebook/presto/elasticsearch/TestPasswordConfig.java
+++ b/src/test/java/com/facebook/presto/elasticsearch/TestPasswordConfig.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestPasswordConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(PasswordConfig.class)
+                .setUser(null)
+                .setPassword(null));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("elasticsearch.auth.user", "user")
+                .put("elasticsearch.auth.password", "password")
+                .build();
+
+        PasswordConfig expected = new PasswordConfig()
+                .setUser("user")
+                .setPassword("password");
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/src/test/java/com/facebook/presto/elasticsearch/client/TestExtractAddress.java
+++ b/src/test/java/com/facebook/presto/elasticsearch/client/TestExtractAddress.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch.client;
+
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.elasticsearch.client.ElasticsearchClient.extractAddress;
+import static org.testng.Assert.assertEquals;
+
+public class TestExtractAddress
+{
+    @Test
+    public void test()
+    {
+        assertEquals(extractAddress("node/1.2.3.4:9200"), Optional.of("node:9200"));
+        assertEquals(extractAddress("1.2.3.4:9200"), Optional.of("1.2.3.4:9200"));
+        assertEquals(extractAddress("node/1.2.3.4:9200"), Optional.of("node:9200"));
+        assertEquals(extractAddress("node/[fe80::1]:9200"), Optional.of("node:9200"));
+        assertEquals(extractAddress("[fe80::1]:9200"), Optional.of("[fe80::1]:9200"));
+
+        assertEquals(extractAddress(""), Optional.empty());
+        assertEquals(extractAddress("node/1.2.3.4"), Optional.empty());
+        assertEquals(extractAddress("node/1.2.3.4:xxxx"), Optional.empty());
+        assertEquals(extractAddress("1.2.3.4:xxxx"), Optional.empty());
+    }
+}

--- a/src/test/resources/elasticsearch.yml
+++ b/src/test/resources/elasticsearch.yml
@@ -1,0 +1,4 @@
+cluster.name: "docker-cluster"
+network.host: 0.0.0.0
+
+xpack.security.enabled: true

--- a/src/test/resources/roles.yml
+++ b/src/test/resources/roles.yml
@@ -1,0 +1,6 @@
+admin:
+  cluster:
+    - all
+  indices:
+    - names: '*'
+      privileges: [ all ]

--- a/src/test/resources/users
+++ b/src/test/resources/users
@@ -1,0 +1,1 @@
+elastic_user:$2a$10$tbO62EbOfqMezJDBDWlxbuvIleeYeNlw30F5OgWMXzi1R8aXqnVni

--- a/src/test/resources/users_roles
+++ b/src/test/resources/users_roles
@@ -1,0 +1,1 @@
+admin:elastic_user


### PR DESCRIPTION
Upgrading the Presto Elasticsearch connector to use Elasticsearch 7.0
libraries will introduce breaking changes for supporting Elasticsearch 6.0
servers due to the lack of backward compatibility in the Elasticsearch 
v7.0 RestHighLevelClient (HLC) and the Types deprecated in APIs in 
ES 7.0 introducing breaking changes to the index creation, put mapping, 
get mapping, put template, get template and get field mappings APIs.

By forking and creating a presto-elasticsearch-6 version of the 
Elasticsearch connector as a new module we can mitigate these 
breaking changes so users can stay using the older connector code if 
they need to stay on the older ES 6.x servers.  As it's own module we can
release this independently and provide instructions for users to retain 
ES6 access. If it goes as a submodule in the main Presto repository it can 
cause issues with CI and the versioning won't make sense since it would 
follow Presto's versioning, when as a standalone plugin it should be 
versioned independently.

The existing presto-elasticsearch module source, tests, and config files 
were copied, renamed to presto-elasticsearch-6 and copied thi new 
repository. Update the name of the plugin to ElasticsearchLegacyPlugin 
and the connector name to elasticsearch_legacy to avoid conflicts.

## Description
Make a copy of the code in the existing presto-elasticsearch
module and rename it to presto-elasticsearch-6. Copy, duplicate, and
rename any references to the presto-elasticsearch module with the
presto-elasticsearch-6 reference. Update the name of the plugin to 
ElasticsearchLegacyPlugin and the connector name to 
elasticsearch_legacy to avoid conflicts. Move this code into new
repository called presto-elasticsearch-6 as it's own independent
module. 

## Motivation and Context
Moving to Elasticsearch 7.0 libraries will introduce breaking changes 
to the Presto Elasticsearch connector with Elasticsearch 6.0 servers 
due to lack of backward compatibility. By forking and creating a 
presto-elasticsearch-6 version of the Elasticsearch connector based
on the current code we can mitigate these breaking changes so 
users can stay using the older connector code if they need to stay on 
the older ES 6.x servers. 
https://github.com/prestodb/presto/issues/23470

## Impact
Presto will provide two Elasticsearch connectors. 
The presto-elasticsearch-6 version of the connector will be for
Elasticsearch v6 servers while the presto-elasticsearch version will be
for Elasticsearch v7 servers.

## Test Plan
Copied the existing 56 tests in the Presto Elasticsearch connector
and made sure they are still running as-is.

## Contributor checklist

- [x] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Connectors
* Add a presto-elasticsearch-6 module to keep support for a Presto Elasticsearch connector for Elasticsearch 6.0 servers.  Change the plugin name to ElasticsearchLegacyPlugin and connector name to elasticsearch_legacy to avoid conflicting with the existing Elasticsearch plugin. :pr:`23500`
